### PR TITLE
chore: tidy stray security.txt and stale .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,2 +1,0 @@
-# Keep secrets out of git. Example placeholders only.
-CONTACT_EMAIL=hello@okarthur.com

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,3 +1,3 @@
 Contact: mailto:steven@okarthur.com
-Expires: 2026-08-28T00:00:00Z
+Expires: 2027-07-01T00:00:00Z
 Policy: https://okarthur.com/privacy.html


### PR DESCRIPTION
Delete the empty root security.txt (the real one lives at .well-known/security.txt), refresh its Expires date, and remove .env.template since this is a static site with no runtime and it only held a stale hello@ contact placeholder.