### PR TITLE
chore: add Claude Code settings and ignore local overrides

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/claude-code-settings.json",
+  "permissions": {
+    "deny": [
+      "Read(.env)",
+      "Read(**/.env)",
+      "Bash(git push --force*)",
+      "Bash(git push -f*)"
+    ],
+    "allow": [
+      "Bash(make check)",
+      "Bash(make lint)",
+      "Bash(make fmt)",
+      "Bash(pre-commit run*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 .cache/
 dist/
 build/
+
+# Claude Code local settings
+.claude/settings.local.json


### PR DESCRIPTION
Adds a shared .claude/settings.json with sensible permission defaults, and ignores .claude/settings.local.json so personal overrides don't get committed.