### PR TITLE
ci: bump actions/checkout, setup-python and setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - run: python -m pip install -U pip

--- a/.github/workflows/html-validate.yml
+++ b/.github/workflows/html-validate.yml
@@ -6,8 +6,8 @@ jobs:
   htmlhint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
       - name: Run HTMLHint

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -6,7 +6,7 @@ jobs:
   lychee:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: lycheeverse/lychee-action@v1
         with:
           args: --verbose --no-progress --accept 429,403 --exclude-mail '^mailto:'


### PR DESCRIPTION
Applies the safe subset of Dependabot's github-actions group bump. lychee-action stays pinned at v1 — v2 has a known startup crash.