### PR TITLE
ci: ignore major version bumps for lychee-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,7 @@ updates:
       github-actions:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "lycheeverse/lychee-action"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
v2 has a known startup crash. Patch and minor updates still arrive; major bumps stay off until it's fixed upstream.