### PR TITLE
security: widen project pre-commit deny rules to match global settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,8 +4,18 @@
     "deny": [
       "Read(.env)",
       "Read(**/.env)",
+      "Read(.env.local)",
+      "Read(**/.env.local)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Read(~/.ssh/**)",
+      "Read(~/.aws/**)",
+      "Read(~/.config/rclone/**)",
+      "Read(~/.claude/.credentials.json)",
       "Bash(git push --force*)",
-      "Bash(git push -f*)"
+      "Bash(git push -f*)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean -f*)"
     ],
     "allow": [
       "Bash(make check)",


### PR DESCRIPTION
Add .env.local, .pem, .key, SSH/AWS/rclone, and git reset --hard/clean -f denies so this repo's local settings provide the same protection as the user's global ~/.claude/settings.json.