### PR TITLE
Tidy tooling config after cutover

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,10 +18,10 @@
       "Bash(git clean -f*)"
     ],
     "allow": [
-      "Bash(make check)",
-      "Bash(make lint)",
-      "Bash(make fmt)",
-      "Bash(pre-commit run*)"
+      "Bash(npm ci)",
+      "Bash(npm run build)",
+      "Bash(npm run dev)",
+      "Bash(npm run preview)"
     ]
   }
 }

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "astro-new",
+  "name": "okarthur-site",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "astro-new",
+      "name": "okarthur-site",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/rss": "4.0.19",

--- a/site/package.json
+++ b/site/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "astro-new",
+  "name": "okarthur-site",
+  "private": true,
   "type": "module",
   "version": "0.0.1",
   "engines": {


### PR DESCRIPTION
Replace the Claude allow list's make and pre-commit entries, both removed in the cutover, with the npm scripts this repo actually uses. Deny rules are unchanged.

Name the package okarthur-site rather than the astro-new scaffold default and mark it private, so the marketing site cannot be published to npm by accident. package-lock.json is resynced; no dependency versions change.