### PR TITLE
Drop obsolete okarthur.com exclusion from linkcheck

### DIFF
--- a/.github/workflows/astro-ci.yml
+++ b/.github/workflows/astro-ci.yml
@@ -44,14 +44,12 @@ jobs:
         working-directory: site
       - uses: lycheeverse/lychee-action@v1
         with:
-          # Both excludes are load-bearing; do not remove.
-          # okarthur.com: our own canonical/og:url tags point at the live site,
-          #   where the new routes do not exist until cutover.
+          # This exclude is load-bearing; do not remove.
           # linkedin.com: LinkedIn blocks automated clients, answering 999 from
           #   some IPs and 403/429 from GitHub runners. The latter counts as an
           #   error, so leaving it in makes this required check fail at random.
           # External links other than these are still checked.
-          args: --no-progress --exclude '^https://okarthur\.com' --exclude 'linkedin\.com' site/dist
+          args: --no-progress --exclude 'linkedin\.com' site/dist
           format: json
           output: lychee/out.json
           fail: false

--- a/site/src/components/Seo.astro
+++ b/site/src/components/Seo.astro
@@ -3,9 +3,10 @@ interface Props {
 	title: string;
 	description: string;
 	ogType?: 'website' | 'article';
+	noindex?: boolean;
 }
 
-const { title, description, ogType = 'website' } = Astro.props;
+const { title, description, ogType = 'website', noindex = false } = Astro.props;
 
 const fullTitle = `${title} | OkArthur`;
 
@@ -15,11 +16,11 @@ const canonical = new URL(Astro.url.pathname, Astro.site).href;
 
 <title>{fullTitle}</title>
 <meta name="description" content={description} />
-<link rel="canonical" href={canonical} />
+{!noindex && <link rel="canonical" href={canonical} />}
 
 <meta property="og:title" content={fullTitle} />
 <meta property="og:description" content={description} />
 <meta property="og:type" content={ogType} />
-<meta property="og:url" content={canonical} />
+{!noindex && <meta property="og:url" content={canonical} />}
 
 <meta name="twitter:card" content="summary" />

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -69,7 +69,7 @@ const isCurrent = (href: string) =>
 
 		{noindex && <meta name="robots" content="noindex" />}
 
-		<Seo title={title} description={description} ogType={ogType} />
+		<Seo title={title} description={description} ogType={ogType} noindex={noindex} />
 		<JsonLd extra={schema} />
 
 		<script is:inline>


### PR DESCRIPTION
The site is live, so canonical/og:url self-references now resolve. Keep the linkedin.com exclusion, which is unrelated.