### PR TITLE
Cross-link the digital twin and reliance question notes

### DIFF
--- a/site/src/content/notes/the-reliance-question.md
+++ b/site/src/content/notes/the-reliance-question.md
@@ -15,3 +15,5 @@ The pattern I see on live programmes is consistent. A team proves a capability, 
 So the useful work happens early and it is unglamorous. Name the owner before you name the tool. Write the information you will need to run the asset into the contract as a requirement with an owner and a standard, not as a hope you will sort out later. Then ask, at every gate, one plain question. If the people who built this walked away tomorrow, could we still rely on it? If the answer is no, you have a procurement problem wearing the costume of a technical one.
 
 Whether a capability can be relied on is answered by who owns it and what the contract asked for, and both are settled before anyone switches it on.
+
+A [digital twin](/notes/what-makes-a-digital-twin-worth-relying-on) is one place this plays out in detail, where reliance turns into a test of what the model shows and how current it needs to be for a given decision.

--- a/site/src/content/notes/what-makes-a-digital-twin-worth-relying-on.md
+++ b/site/src/content/notes/what-makes-a-digital-twin-worth-relying-on.md
@@ -14,7 +14,7 @@ That distinction matters. A digital twin is not reliable in general. It is relia
 
 A useful digital twin is a digital representation of an asset or system that is maintained for specified uses. The word doing the work is maintained. It does not need to reproduce everything about the asset, and it does not need every element to be updated at the same frequency. It does need to remain current and complete enough, within agreed tolerances, for the decisions it is intended to support.
 
-For me, reliance is the point at which someone is prepared to act on the information without repeating every check independently. That does not mean accepting the system without question. It means there is enough evidence about the information, its status and its limitations to decide how far it can be used.
+For me, [reliance](/notes/the-reliance-question) is the point at which someone is prepared to act on the information without repeating every check independently. That does not mean accepting the system without question. It means there is enough evidence about the information, its status and its limitations to decide how far it can be used.
 
 ## Reliability depends on the decision
 


### PR DESCRIPTION
## Summary
- Links "reliance" in "What makes a digital twin worth relying on" to `/notes/the-reliance-question`
- Adds a closing paragraph in "The reliance question" linking to `/notes/what-makes-a-digital-twin-worth-relying-on`
- Both notes are already live on main; this only adds internal cross-links

## Test plan
- [x] `npm run build` succeeds
- [x] `dist/notes/what-makes-a-digital-twin-worth-relying-on/index.html` contains `href="/notes/the-reliance-question"`
- [x] `dist/notes/the-reliance-question/index.html` contains `href="/notes/what-makes-a-digital-twin-worth-relying-on"`
- [x] No literal markdown brackets leaked into either rendered page
- [ ] CI: build, gitleaks, linkcheck all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)