### PR TITLE
Add Content Signals line to robots.txt

### DIFF
--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -2,6 +2,8 @@
 
 User-agent: *
 Allow: /
+# Content Signals (contentsignals.org): open to search indexing and real-time AI answers, not to model training.
+Content-Signal: search=yes, ai-input=yes, ai-train=no
 
 # Named explicitly so that a future default-deny stance elsewhere, or a
 # crawler that looks for its own name before falling back to *, still


### PR DESCRIPTION
## Summary
- Adds a Content Signals line (contentsignals.org) to the `User-agent: *` group in `site/public/robots.txt`
- Declares open to search indexing and AI-input use, closed to AI model training
- No other lines touched: named user-agent groups and the Sitemap line are unchanged

## Test plan
- [x] `npm run build` succeeds
- [x] `dist/robots.txt` contains the new `Content-Signal: search=yes, ai-input=yes, ai-train=no` line exactly as specified
- [x] Diff confirms only the two lines were added
- [ ] CI: build, gitleaks, linkcheck all green