### PR TITLE
Add independent review page

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -19,6 +19,7 @@ const path = Astro.url.pathname;
 
 const sections = [
 	{ href: '/about', label: 'About' },
+	{ href: '/review', label: 'Review' },
 	{ href: '/capabilities', label: 'Capabilities' },
 	{ href: '/notes', label: 'Notes' },
 	{ href: '/contact', label: 'Contact' },

--- a/site/src/pages/review/index.astro
+++ b/site/src/pages/review/index.astro
@@ -1,0 +1,108 @@
+---
+import Base from '../../layouts/Base.astro';
+---
+
+<Base
+	title="Independent review"
+	description="A second opinion on a digital or AI investment decision in infrastructure, before you commit. Fixed scope, fixed end date, one written opinion."
+>
+	<div class="page-head">
+		<h1 class="page-title">Independent review</h1>
+		<p class="lede">
+			A second opinion on a digital or AI investment decision, before you
+			commit.
+		</p>
+	</div>
+
+	<div class="prose reveal">
+		<p>
+			Digital and AI investments are usually approved on evidence assembled
+			by people who benefit from approval. The supplier wants the contract.
+			The delivery team wants the programme. The adviser wants the
+			follow-on. An independent review gives you the one thing none of them
+			can, a written opinion from someone with no stake in the outcome.
+		</p>
+
+		<h2>When it applies</h2>
+		<p>Before accepting a supplier's proposal for a digital or AI system.</p>
+		<p>
+			Before funding, or continuing to fund, a digital twin or data
+			platform.
+		</p>
+		<p>Before accepting handover of a digital asset into operation.</p>
+		<p>
+			Before a business case goes to an investment committee, when someone
+			has to say whether the evidence supports the claim being made.
+		</p>
+
+		<h2>What is reviewed</h2>
+		<p>
+			The material that already exists. The business case, the supplier's
+			proposal, the stated information requirements, and whatever assurance
+			evidence has been produced. A small number of interviews across
+			owner, supplier and operator, agreed and named before work starts.
+		</p>
+		<p>
+			The decision is then tested against four questions. What decision
+			does this evidence actually support. What would have to be true for
+			the claim to hold. What breaks it. What does it cost to keep true
+			after year one.
+		</p>
+
+		<h2>What you receive</h2>
+		<p>
+			A single written opinion, short enough for a board to read and
+			specific enough to act on. It states what the evidence supports and
+			what it does not, the conditions under which the investment is
+			defensible, and the risks that matter, with their severity. One
+			session presenting it to the sponsor or the board. A one-page summary
+			you can lift into your own paper.
+		</p>
+		<p>
+			Every opinion carries a reliance statement on its front page,
+			bounding it to the decision reviewed, the material examined and the
+			date it was issued. That is not small print. An opinion, like a
+			digital twin, is <a
+				href="/notes/what-makes-a-digital-twin-worth-relying-on/"
+				>worth relying on only within stated limits</a
+			>.
+		</p>
+
+		<h2>How it runs</h2>
+		<p>
+			Fixed scope and a fixed end date, agreed before work starts.
+			Typically three to four weeks from kickoff. A fixed fee, proposed
+			within two working days of a first call. No time and materials.
+		</p>
+
+		<h2>The independence rule</h2>
+		<p>
+			On any review, I take no delivery work, no supplier-side work and no
+			stake in the system being reviewed. Any interest is declared before
+			the engagement starts. If a conflict cannot be cleanly separated, I
+			decline the engagement.
+		</p>
+
+		<h2>Out of scope</h2>
+		<p>
+			No implementation and no delivery resource. No running the supplier
+			selection, though a completed selection can be reviewed. No
+			certification and no regulatory sign-off. The supplier's technical
+			work is examined, not redone.
+		</p>
+
+		<h2>Beyond the review</h2>
+		<p>
+			Continuing independent advisory to owners often follows a review.
+			Non-executive, speaking and writing work sits alongside the practice.
+			If the review is not the shape of what you need, say so in the same
+			message.
+		</p>
+
+		<h2>Start here</h2>
+		<p>
+			<a href="/contact/">Tell me the decision you are facing</a> and when
+			it has to be made.
+		</p>
+	</div>
+</Base>


### PR DESCRIPTION
## Summary
- New page at `/review/` for the independent review offering, following the `capabilities/index.astro` structure (page-head, h1, lede, then body sections).
- Added "Review" to the site nav in `Base.astro`, placed immediately before Capabilities (Capabilities itself is untouched, to be removed in a later PR).
- Two inline links as specified: "worth relying on only within stated limits" → `/notes/what-makes-a-digital-twin-worth-relying-on/`, and "Tell me the decision you are facing" → `/contact/`.

## Test plan
- [x] `npm run build` passes
- [x] `grep -ril "TODO" dist/` and `grep -ril "lorem" dist/` both empty
- [x] Verified `/review/` appears in nav before Capabilities, with correct `aria-current` highlighting
- [x] Verified both inline links resolve to real built pages in `dist/`