### PR TITLE
Point home at the independent review

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -12,11 +12,11 @@ const website = {
 
 const gateways = [
 	{
-		href: '/capabilities',
-		label: 'What I do',
-		target: 'Capabilities',
+		href: '/review',
+		label: 'What you can commission',
+		target: 'Independent review',
 		teaser:
-			'The advisory work, from data and AI strategy to digital twins and capital delivery transformation.',
+			'A second opinion on a digital or AI investment decision. Fixed scope, fixed end date, one written opinion.',
 	},
 	{
 		href: '/notes',
@@ -37,17 +37,19 @@ const gateways = [
 
 <Base
 	title="Home"
-	description="Steven Yule, chartered engineer and digital and data leader, turning asset and operational evidence into investment decisions for infrastructure."
+	description="Steven Yule, chartered civil engineer giving owners an independent read on digital and AI investment decisions in infrastructure and capital programmes."
 	schema={[website]}
 >
-	<h1 class="hero-title">Making technology useful in live capital delivery.</h1>
+	<h1 class="hero-title">
+		Independent review of digital and AI investment decisions.
+	</h1>
 	<p class="standfirst">
-		I'm Steven Yule, a chartered civil engineer and commercial leader in
-		digital, data and AI for infrastructure. I turn asset and operational
-		evidence into investment decisions for capital programmes and asset
-		owners across the GCC and UK. My work starts where most digital work is
-		treated as finished, at the point a capability has been demonstrated but
-		not yet relied on, on a live programme.
+		I'm Steven Yule, a chartered civil engineer working at director level in
+		digital, data and AI for infrastructure, across the GCC and UK. When an
+		owner is about to commit, to a supplier's proposal, a digital twin, a
+		handover, or a business case, I give them a written opinion from someone
+		with no stake in the outcome. Fixed scope, a fixed end date, one
+		document a board can act on.
 	</p>
 
 	<nav class="gateways reveal" aria-label="Main sections">


### PR DESCRIPTION
## Summary
- Repoint the home page hero, standfirst and Base description at the independent review offering, per merged/deployed `/review/` page in #44.
- Swap the first gateway card from Capabilities (`/capabilities`) to `/review`, "What you can commission" / "Independent review". Notes and About gateway cards unchanged.

## Test plan
- [x] `npm run build` passes
- [x] Verified `dist/index.html` renders the new h1, description meta, and `/review` gateway href