### PR TITLE
Shape the contact enquiry around the review

### DIFF
--- a/site/src/pages/contact.astro
+++ b/site/src/pages/contact.astro
@@ -4,7 +4,7 @@ import Base from '../layouts/Base.astro';
 
 <Base
 	title="Contact"
-	description="Contact Steven Yule at OkArthur. Email steven@okarthur.com about advisory, board, speaking and digital delivery in infrastructure."
+	description="Contact Steven Yule at OkArthur about an independent review of a digital or AI investment decision, or about advisory, board, speaking and writing work."
 >
 	<div class="page-head">
 		<h1 class="page-title">Contact</h1>
@@ -16,19 +16,20 @@ import Base from '../layouts/Base.astro';
 			connect on <a href="https://www.linkedin.com/in/stevenyule">LinkedIn</a>.
 		</p>
 
-		<h2>Ways to work together</h2>
+		<h2>If you are considering a <a href="/review/">review</a></h2>
 		<p>
-			I take on advisory and consulting engagements in the areas above. I am
-			also open to non-executive and board roles, to speaking, and to
-			writing for infrastructure and engineering publications. A general
-			enquiry and a specific brief reach the same place, so start wherever
-			suits.
+			Three things make the first call short and useful. The decision you
+			are facing, and when it has to be made. What has been proposed or
+			delivered, described by role rather than by name. Who needs to be
+			convinced. What happens next is a short call, then a fixed-fee
+			proposal within two working days.
 		</p>
 
-		<h2>Media</h2>
+		<h2>Everything else</h2>
 		<p>
-			For comment on digital, data and AI in infrastructure, email the same
-			address and mark it a press enquiry.
+			Advisory engagements, non-executive and board roles, speaking and
+			writing all reach the same address. For media comment on digital,
+			data and AI in infrastructure, mark it a press enquiry.
 		</p>
 	</div>
 </Base>


### PR DESCRIPTION
## Summary
- Update the contact page Base description to lead with the independent review offering.
- Replace the prose body: keep the email/LinkedIn line, add an "If you are considering a review" section (linking "review" to `/review/`) describing what makes a first call short and useful, and fold the old "Ways to work together" and "Media" sections into a single "Everything else" section.

## Test plan
- [x] `npm run build` passes
- [x] Verified rendered `dist/contact/index.html` prose block matches the spec copy exactly, including the `/review/` link
- [x] Verified description meta and page-head/h1 unchanged
- [x] `grep -ril "TODO"` / `"lorem"` over `dist/` both empty