### PR TITLE
Add review bridge to note footer

### DIFF
--- a/site/src/pages/notes/[...slug].astro
+++ b/site/src/pages/notes/[...slug].astro
@@ -55,5 +55,13 @@ const article = {
 		<div class="prose note-body">
 			<Content />
 		</div>
+
+		<aside class="note-bridge reveal">
+			<p>
+				Notes like this one usually trace back to a live decision. If you
+				are facing one, <a href="/review/">an independent review</a> gives
+				you a written opinion before you commit.
+			</p>
+		</aside>
 	</article>
 </Base>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -890,6 +890,33 @@ hr::after {
 	border-bottom: 1px solid var(--rule);
 }
 
+.note-bridge {
+	margin-top: var(--s-8);
+	padding-top: var(--s-6);
+	border-top: 1px solid var(--rule);
+	max-width: var(--measure);
+}
+
+.note-bridge p {
+	color: var(--muted);
+	text-wrap: pretty;
+}
+
+.note-bridge a {
+	color: var(--ink);
+	text-decoration: underline;
+	text-decoration-color: var(--accent);
+	text-decoration-thickness: 1px;
+	text-underline-offset: 0.16em;
+	text-decoration-skip-ink: auto;
+	transition: color var(--transition), text-decoration-thickness var(--transition);
+}
+
+.note-bridge a:hover {
+	color: var(--accent);
+	text-decoration-thickness: 2px;
+}
+
 /* 11. Motion ==============================================================
    Off unless the visitor has expressed no preference against it, and off
    entirely without JavaScript: the hiding rule requires the .js class that


### PR DESCRIPTION
## Summary
- Add a closing `<aside class="note-bridge reveal">` to the note template (`site/src/pages/notes/[...slug].astro`), after the prose note body, linking "an independent review" to `/review/`.
- Add minimal `.note-bridge` styling in `global.css`, reusing the site's existing quiet-footer pattern (top border, `--muted` text, `--measure` width) already used by `.origin-note` and `.elsewhere`, so it reads as a footer rather than a banner.

## Test plan
- [x] `npm run build` passes
- [x] Verified the aside renders exactly once, with the exact copy and `/review/` link, on all three notes in `dist/`
- [x] Verified `note-bridge` does not appear on non-note pages (`/notes/`, `/review/`, etc.)
- [x] `grep -ril "TODO"` / `"lorem"` over `dist/` both empty