### PR TITLE
Correct the legacy URL entry in CARRYOVER

### DIFF
--- a/CARRYOVER.md
+++ b/CARRYOVER.md
@@ -24,15 +24,30 @@ so it is not awaiting sign-off.
    appears anywhere in `site/`. Home, Contact, Notes and the new `/review/`
    page now share the independent-review framing.
 
-2. **Old URLs die at cutover.** `/about.html`, `/privacy.html`, `/terms.html`
-   and `/notes/foundations-first.html` become `/about/`, `/privacy/`, `/terms/`
-   and `/notes/foundations-first/`. `foundations-first.html` is live and
-   indexed today. A Cloudflare Bulk Redirect rule would preserve them.
+2. **Legacy `.html` URLs, partly covered.** A Cloudflare redirect exists, but
+   it only ever covered two of the four, and one of those has since rotted.
+   Measured against the live site on 12 July 2026:
 
-3. **`/capabilities/` is retired.** The page was deleted once `/review/`
-   replaced it. The URL was live and is linked from outside the site, so it
-   needs a Cloudflare redirect to `/review/`, in place as soon as the
-   retirement deploys.
+   | URL | Now |
+   | --- | --- |
+   | `/about.html` | 301 to `/about/`, which is 200. Correct. |
+   | `/notes/foundations-first.html` | 301 to `/notes/foundations-first/`, **which is a 404**. |
+   | `/privacy.html` | 404, never redirected. |
+   | `/terms.html` | 404, never redirected. |
+
+   The `foundations-first` chain broke when that note was deliberately deleted
+   in `d7d82b9` (11 July 2026), leaving a redirect pointing at a page that no
+   longer exists. A 301 into a 404 is worse than a plain 404, because crawlers
+   follow it and find nothing. **Repoint that rule at `/notes/`**, which is a
+   reasonable home for anyone still arriving from an indexed link.
+
+   `/privacy.html` and `/terms.html` are left to 404 on purpose. Nobody
+   deep-links a privacy policy, and an honest 404 beats an invented target.
+
+3. ~~**`/capabilities/` is retired.**~~ Done. The page was deleted once
+   `/review/` replaced it, and a Cloudflare redirect rule now sends both
+   `/capabilities` and `/capabilities/` to `/review/` with a 301. Verified
+   against the live site.
 
 ## Deliberately excluded from the site
 


### PR DESCRIPTION
## Summary

Docs only. `CARRYOVER.md` said the legacy `.html` URLs still needed a Cloudflare redirect. That is no longer accurate, and the truth is worse than the doc suggested.

Measured against the live site:

| URL | Now |
| --- | --- |
| `/about.html` | 301 → `/about/` → 200. Correct. |
| `/notes/foundations-first.html` | 301 → `/notes/foundations-first/` → **404** |
| `/privacy.html` | 404, never redirected |
| `/terms.html` | 404, never redirected |

So the redirect only ever covered two of the four, and the `foundations-first` one has since rotted: that note was deliberately deleted in `d7d82b9` (11 July), after the rule was written, so the 301 now points at a page that does not exist. A 301 into a 404 is worse than a plain 404 — crawlers follow it and find nothing.

This PR records that state and flags the fix. It does **not** change the redirect itself, which is a Cloudflare dashboard action.

Also marks the `/capabilities/` item done, since that redirect is now deployed and verified.

## Action still outstanding (manual, Cloudflare)

Repoint the `foundations-first` rule's target to `https://okarthur.com/notes/`.

## Test plan

- [x] Every status code in the table verified with `curl -sI` against the live site
- [x] Deletion of the note traced to `d7d82b9`, confirmed on `main`
- [x] Docs-only change; no site source touched