### PR TITLE
Positioning sweep to independent review line

### DIFF
--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,9 @@
 
 OkArthur is the site of Steven Yule, a chartered civil engineer (CEng FICE
 FCIHT MIAM) and director of digital and data, based in Dubai. He is an ICE
-Policy Fellow and the ICE UAE Country Representative. The site covers his
+Policy Fellow and the ICE UAE Country Representative. Through OkArthur he
+offers an independent review, a second opinion on a digital or AI investment
+decision, with a fixed scope and one written opinion. The site covers his
 work on digital, data and infrastructure transformation, and his writing on
 the same. Contact: steven@okarthur.com
 

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -20,7 +20,7 @@ import Base from '../layouts/Base.astro';
 		</p>
 		<p>
 			My work sits where engineering credibility meets commercial
-			leadership. I've built and led multidisciplinary teams across digital
+			judgement. I've built and led multidisciplinary teams across digital
 			strategy, data engineering, data science and software delivery, and
 			I've carried the growth, governance and delivery of a regional digital
 			and data practice. That combination matters. It takes engineering


### PR DESCRIPTION
## Summary

The sweep found almost nothing to sweep, which is the main result.

**Step 1 returned zero hits for all three phrases.** `git log -S` shows "commercial leader" last existed in `d6afabe` — the "Point home at the independent review" commit from earlier in this sequence. All three phrases lived in `index.astro`, and rewriting the home page removed them. So the estate was already clean before this branch started.

That left two real changes:

- **`site/public/llms.txt`** — add the independent review sentence to the opening paragraph, after the sentence describing his roles.
- **`site/src/pages/about.astro`** — reword "commercial **leadership**" to "commercial **judgement**" in paragraph two.

## Why the About edit, given step 2 said not to rewrite the page

Step 6's check (`grep "commercial leader" site/dist` → zero matches) **failed**, because "commercial leader" is a substring of "commercial leadership" in About paragraph two. That is biography, not the old positioning line, so steps 2 and 6 pulled against each other. Raised it rather than pick silently; Steven chose the reword. Meaning survives, and "commercial discipline" later in the same paragraph is untouched.

## Steps that needed no action, and why

- **Step 2 (About intro):** its condition was not met. The intro already reads "a chartered civil engineer and a digital, data and AI leader working at director level in infrastructure, based in Dubai" — the target sentence in all but word order. The `description` prop already avoids the old language, so per the brief it stays.
- **Step 3 (`schema.ts`):** `jobTitle` is `'Digital, data and infrastructure transformation director'`. Contains none of the old phrases, so left as is.
- **Step 5:** nothing to fix — step 1 found no hits.
- Note content under `site/src/content/notes/` untouched, as instructed.

## Test plan

- [x] `npm run build` passes (11 pages)
- [x] `grep -ril "commercial leader" site/dist` → **zero matches**
- [x] Other two phrases also zero in `dist/`
- [x] `commercial judgement` and `commercial discipline` both still present in About
- [x] New llms.txt sentence served in `dist/llms.txt`