### PR TITLE
Remove dead .tick CSS and align About and RSS copy

### DIFF
--- a/CARRYOVER.md
+++ b/CARRYOVER.md
@@ -1,21 +1,21 @@
-# Carry-over: copy needs sign-off before or during Phase 7
+# Carry-over
 
-The Astro site's placeholder copy was drafted from
-`Steven Yule CV - June 26.docx` rather than written by Steven. It reads
-plausibly and contains no invented facts, but **nobody has approved the
-wording**. Treat everything below as draft until it is read and signed off.
+The Astro site's original copy was drafted from
+`Steven Yule CV - June 26.docx` rather than written by Steven, and was
+carried here awaiting sign-off.
 
-## Drafted copy awaiting sign-off
+## Drafted copy: cleared
 
-| File | What was drafted |
+Nothing is outstanding. The drafted copy has since been replaced or
+approved, page by page:
+
+| File | Now |
 | --- | --- |
-| `site/src/pages/about.astro` | Page headline and two-paragraph biography |
-| `site/src/pages/rss.xml.ts` | RSS feed description |
-| `*.astro` | Meta descriptions (also used for `og:description`) |
-
-The Capabilities page has since been retired, and the Home page rewritten
-around the independent review. That copy was written rather than drafted,
-so it is not awaiting sign-off.
+| `site/src/pages/index.astro` | Rewritten around the independent review. |
+| `site/src/pages/capabilities/index.astro` | Page retired; `/review/` replaced it. |
+| `site/src/pages/contact.astro` | Rewritten to shape the enquiry. |
+| `site/src/pages/about.astro` | Bio kept and approved; meta description and the review paragraph written. |
+| `site/src/pages/rss.xml.ts` | Feed description aligned to the review line. |
 
 ## Known issues to fix
 

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -4,7 +4,7 @@ import Base from '../layouts/Base.astro';
 
 <Base
 	title="About"
-	description="Steven Yule, chartered civil engineer, ICE fellow and director-level digital, data and AI leader for infrastructure, based in Dubai."
+	description="Steven Yule, chartered civil engineer and ICE fellow in Dubai, giving owners an independent read on digital and AI investment decisions in infrastructure."
 >
 	<div class="page-head">
 		<h1 class="page-title">About OkArthur</h1>
@@ -37,6 +37,12 @@ import Base from '../layouts/Base.astro';
 			depended on, is where I spend most of my time, and it is usually
 			settled earlier than people expect, in procurement and in who owns
 			what at handover.
+		</p>
+		<p>
+			That work now usually takes one shape. An owner is about to commit,
+			to a supplier's proposal, a platform, a handover, and wants a second
+			opinion from someone with no stake in the outcome. That is what the
+			<a href="/review/">independent review</a> is.
 		</p>
 		<p>
 			My background spans transport, utilities, smart cities, the built

--- a/site/src/pages/rss.xml.ts
+++ b/site/src/pages/rss.xml.ts
@@ -8,7 +8,7 @@ export async function GET(context: APIContext) {
 	return rss({
 		title: 'OkArthur — Notes',
 		description:
-			'Short notes on digital, data and AI in capital delivery, from OkArthur.',
+			'Notes from Steven Yule on digital and AI investment decisions in infrastructure and capital programmes.',
 		site: context.site!,
 		items: notes
 			.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -342,22 +342,6 @@ main {
 	}
 }
 
-/* A benchmark tick: a short accent mark struck off the datum at the level
-   of a heading. Structural, not decorative — it says "a level is set here". */
-.tick {
-	position: relative;
-}
-
-.tick::before {
-	content: '';
-	position: absolute;
-	left: calc(-1 * var(--rail));
-	top: 0.62em;
-	width: calc(var(--rail) * 0.62);
-	height: 2px;
-	background-color: var(--accent);
-}
-
 /* 8. Masthead and footer ================================================== */
 
 .masthead {
@@ -966,7 +950,6 @@ hr::after {
 		border-bottom: 1px solid #000;
 	}
 
-	.tick::before,
 	.entry-meta::before {
 		display: none;
 	}


### PR DESCRIPTION
## Summary

Three things: the dead `.tick` rule, the About page, and the RSS description.

### 1. `.tick` removed

Its only user was `class="capability-title tick"` on the Capabilities page, deleted in #48. Zero usages remained in any `.astro`, any note, or any built page. Removed the rule, its comment, and its entry in the `@media print` selector list.

`.entry-meta::before` shared that print selector and is **preserved** — verified by diffing the minified print block against the live site: `.tick:before,.entry-meta:before{display:none}` becomes `.entry-meta:before{display:none}`.

### 2. About page — please read this bit

The real gap was not stale wording. It was that About **never said what the practice now does** — a reader met the background and never met the offer. Two edits:

- **New paragraph** after the "reliance gap" paragraph, landing the review where the page already builds to it, linking to `/review/`.
- **Meta description** rewritten to carry the new line. Deliberately *not* the homepage sentence verbatim — duplicate meta descriptions across pages hurt in search — so it keeps the ICE-fellow-in-Dubai specifics.

**Your biography itself is untouched.** The two-paragraph bio stands exactly as written. I'm proposing the addition, not rewriting your self-description.

### 3. RSS description

`"Short notes on digital, data and AI in capital delivery, from OkArthur."`
→ `"Notes from Steven Yule on digital and AI investment decisions in infrastructure and capital programmes."`

### 4. CARRYOVER

The "drafted copy awaiting sign-off" section is cleared. Every item is now either replaced or approved, recorded page by page. That was the original purpose of the file, and it is now discharged.

## Test plan

- [x] `npm run build` passes (11 pages)
- [x] `.tick` gone from source and built CSS; print block diffed against live to confirm `.entry-meta` survived
- [x] New RSS description present in `dist/rss.xml`
- [x] About renders the `/review/` link and the new meta description