### PR TITLE
Fix fused links, bullet the review lists, open external links in a new tab

### DIFF
--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -13,8 +13,8 @@ import Base from '../layouts/Base.astro';
 
 	<div class="prose">
 		<p>
-			That page isn't here, or has moved. Return to the
-			<a href="/">home page</a>, or read the <a href="/notes">notes</a>.
+			That page isn't here, or has moved. Return to
+			the <a href="/">home page</a>, or read the <a href="/notes">notes</a>.
 		</p>
 	</div>
 </Base>

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -41,8 +41,8 @@ import Base from '../layouts/Base.astro';
 		<p>
 			That work now usually takes one shape. An owner is about to commit,
 			to a supplier's proposal, a platform, a handover, and wants a second
-			opinion from someone with no stake in the outcome. That is what the
-			<a href="/review/">independent review</a> is.
+			opinion from someone with no stake in the outcome. That is what
+			the <a href="/review/">independent review</a> is.
 		</p>
 		<p>
 			My background spans transport, utilities, smart cities, the built

--- a/site/src/pages/contact.astro
+++ b/site/src/pages/contact.astro
@@ -13,7 +13,11 @@ import Base from '../layouts/Base.astro';
 	<div class="prose">
 		<p>
 			Email <a href="mailto:steven@okarthur.com">steven@okarthur.com</a>, or
-			connect on <a href="https://www.linkedin.com/in/stevenyule">LinkedIn</a>.
+			connect on <a
+				href="https://www.linkedin.com/in/stevenyule"
+				target="_blank"
+				rel="noopener noreferrer">LinkedIn</a
+			>.
 		</p>
 
 		<h2>If you are considering a <a href="/review/">review</a></h2>

--- a/site/src/pages/notes/index.astro
+++ b/site/src/pages/notes/index.astro
@@ -61,19 +61,19 @@ const isoDate = (date: Date) => date.toISOString().slice(0, 10);
 		<p>Selected writing and talks for other publications and institutions.</p>
 		<ul class="elsewhere-list">
 			<li>
-				<a href="https://www.ice.org.uk/events/recorded-lectures/beyond-engineering-digital-transformation-middle-east">How AI is shaping the built environment in the Middle East</a>
+				<a href="https://www.ice.org.uk/events/recorded-lectures/beyond-engineering-digital-transformation-middle-east" target="_blank" rel="noopener noreferrer">How AI is shaping the built environment in the Middle East</a>
 				<span class="elsewhere-source">Institution of Civil Engineers, recorded lecture</span>
 			</li>
 			<li>
-				<a href="https://open.spotify.com/episode/4ZU81nDTxpErpH06PYYfMB">How digital engineering is improving project delivery</a>
+				<a href="https://open.spotify.com/episode/4ZU81nDTxpErpH06PYYfMB" target="_blank" rel="noopener noreferrer">How digital engineering is improving project delivery</a>
 				<span class="elsewhere-source">The Engineers Collective, podcast</span>
 			</li>
 			<li>
-				<a href="https://www.emerald.com/jsmic/article-abstract/174/2/33/411939/Informing-the-information-requirements-of-a">Informing the information requirements of a digital twin, a rail industry case study</a>
+				<a href="https://www.emerald.com/jsmic/article-abstract/174/2/33/411939/Informing-the-information-requirements-of-a" target="_blank" rel="noopener noreferrer">Informing the information requirements of a digital twin, a rail industry case study</a>
 				<span class="elsewhere-source">Proceedings of the Institution of Civil Engineers, Smart Infrastructure and Construction, 2022</span>
 			</li>
 			<li>
-				<a href="https://de.bentley.com/wp-content/uploads/BSY-121421-TRU.pdf">Civil engineering means going digital</a>
+				<a href="https://de.bentley.com/wp-content/uploads/BSY-121421-TRU.pdf" target="_blank" rel="noopener noreferrer">Civil engineering means going digital</a>
 				<span class="elsewhere-source">Bentley Systems, case study</span>
 			</li>
 		</ul>

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -13,8 +13,8 @@ import Base from '../layouts/Base.astro';
 	<div class="prose">
 		<p>
 			We don’t collect personal data on this site. If you email us, we’ll use
-			your message only to respond. To request updates or deletion, contact
-			<a href="mailto:steven@okarthur.com">steven@okarthur.com</a>.
+			your message only to respond. To request updates or deletion,
+			contact <a href="mailto:steven@okarthur.com">steven@okarthur.com</a>.
 		</p>
 	</div>
 </Base>

--- a/site/src/pages/review/index.astro
+++ b/site/src/pages/review/index.astro
@@ -24,16 +24,24 @@ import Base from '../../layouts/Base.astro';
 		</p>
 
 		<h2>When it applies</h2>
-		<p>Before accepting a supplier's proposal for a digital or AI system.</p>
-		<p>
-			Before funding, or continuing to fund, a digital twin or data
-			platform.
-		</p>
-		<p>Before accepting handover of a digital asset into operation.</p>
-		<p>
-			Before a business case goes to an investment committee, when someone
-			has to say whether the evidence supports the claim being made.
-		</p>
+		<p>The review lands at a decision point, usually one of four.</p>
+		<ul>
+			<li>
+				A supplier's proposal for a digital or AI system, before you
+				accept it.
+			</li>
+			<li>
+				A digital twin or data platform, before you fund it, or fund it
+				again.
+			</li>
+			<li>
+				A digital asset, before you accept handover into operation.
+			</li>
+			<li>
+				A business case, before it reaches an investment committee and
+				someone has to say whether the evidence supports the claim.
+			</li>
+		</ul>
 
 		<h2>What is reviewed</h2>
 		<p>
@@ -42,12 +50,13 @@ import Base from '../../layouts/Base.astro';
 			evidence has been produced. A small number of interviews across
 			owner, supplier and operator, agreed and named before work starts.
 		</p>
-		<p>
-			The decision is then tested against four questions. What decision
-			does this evidence actually support. What would have to be true for
-			the claim to hold. What breaks it. What does it cost to keep true
-			after year one.
-		</p>
+		<p>The decision is then tested against four questions.</p>
+		<ul>
+			<li>What decision does this evidence actually support.</li>
+			<li>What would have to be true for the claim to hold.</li>
+			<li>What breaks it.</li>
+			<li>What does it cost to keep true after year one.</li>
+		</ul>
 
 		<h2>What you receive</h2>
 		<p>


### PR DESCRIPTION
## 1. Fused links — a real bug, on three pages

An `<a>` that **begins a new line** directly after a text line loses the newline in Astro, and the words fuse: `That is what the<a>independent review</a> is.` Inline links are unaffected, which is why only three broke.

| Page | Rendered as | Origin |
| --- | --- | --- |
| `about.astro` | "That is what the**independent review** is." | The paragraph added in #51 |
| `404.astro` | "Return to the**home page**" | **Pre-existing** |
| `privacy.astro` | "deletion, contact**steven@okarthur.com**" | **Pre-existing** |

Only About was reported. The other two surfaced from scanning all 11 built pages for the pattern, and have been live and broken for some time.

Fix: pull the anchor onto the preceding line. Verified by re-running the scanner — **zero fused links across all 11 pages**.

## 2. "When it applies" — bulleted, and de-anaphora'd

Four sentence fragments written as paragraphs. They were a list, so they're a list now. Each item leads with **the thing being reviewed** rather than a fourth consecutive "Before", so the eye scans the nouns:

> The review lands at a decision point, usually one of four.
> - A supplier's proposal for a digital or AI system, before you accept it.
> - A digital twin or data platform, before you fund it, or fund it again.
> - A digital asset, before you accept handover into operation.
> - A business case, before it reaches an investment committee and someone has to say whether the evidence supports the claim.

## 3. The four questions — same treatment, for consistency

"What is reviewed" announced *"four questions"* then ran them together as prose. With the section above becoming bullets, leaving this as a run-on would have been inconsistent. Now a list. The clipped full-stops are kept — that's a deliberate voice, not an error.

## 4. External links open in a new tab

All five: LinkedIn on Contact, and the four "Published elsewhere" works on Notes (ICE, Spotify, Emerald, Bentley). Each gets `target="_blank"` plus `rel="noopener noreferrer"` — the `rel` blocks tabnabbing, where the opened page can rewrite the one it came from.

Verified: no external link remains without it.

## Test plan

- [x] `npm run build` passes (11 pages)
- [x] Whitespace scanner re-run across all built pages: zero fused links
- [x] All three repaired sentences confirmed in rendered HTML
- [x] Both `/review/` lists render as `<ul>`; `.prose ul` was already styled, no new CSS
- [x] All 5 external links carry `target` and `rel`; none left without