### PR TITLE
Ignore the design source assets

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -3,6 +3,9 @@ dist/
 # generated types
 .astro/
 
+# design masters the site is generated from, not shipped with it
+assets-source/
+
 # dependencies
 node_modules/
 


### PR DESCRIPTION
site/assets-source/ holds the masters the shipped assets are exported from, starting with the 973 KB favicon-source.png. They are inputs to the design, not inputs to the build, and Astro never reads them.