### PR TITLE
Lower the display type ceilings on desktop

### DIFF
--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -111,8 +111,8 @@
 	--text-xl: 1.5rem;
 	--text-2xl: 1.875rem;
 	--text-3xl: 2.375rem;
-	--text-title: clamp(2.5rem, 1.4rem + 4.6vw, 4.5rem);
-	--text-hero: clamp(3rem, 1.2rem + 7.4vw, 6.5rem);
+	--text-title: clamp(2.5rem, 1.4rem + 4.6vw, 3.75rem);
+	--text-hero: clamp(3rem, 1.2rem + 7.4vw, 5.25rem);
 
 	--leading-tight: 1.05;
 	--leading-title: 1.12;


### PR DESCRIPTION
The hero reached its 6.5rem (104px) ceiling at a 1146px viewport, so every laptop rendered the home h1 at maximum size. At 1210px it took four lines and roughly 530px of vertical space, pushing the standfirst below the fold. Interior page titles behaved the same way, hitting 4.5rem (72px) from 1080px up.

Only the ceiling argument of each clamp changes. The minimums and the vw slopes are untouched, so the fluid ramp is bit-for-bit identical below an 876px viewport for the hero and 818px for page titles: every phone width and iPad portrait render exactly as before, to 0.0000px.