### PR TITLE
Add entity and structured data for what can be commissioned

### DIFF
--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -7,6 +7,7 @@ const notes = defineCollection({
 		title: z.string(),
 		description: z.string(),
 		pubDate: z.date(),
+		updatedDate: z.date().optional(),
 		draft: z.boolean().default(false),
 	}),
 });

--- a/site/src/lib/schema.ts
+++ b/site/src/lib/schema.ts
@@ -16,4 +16,12 @@ export const person = {
 		addressCountry: 'AE',
 	},
 	sameAs: ['https://www.linkedin.com/in/stevenyule'],
+	knowsAbout: [
+		'Digital twins',
+		'Asset information management',
+		'Infrastructure data strategy',
+		'Artificial intelligence in infrastructure',
+		'Capital programme delivery',
+		'Whole-life asset management',
+	],
 };

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -37,7 +37,7 @@ const gateways = [
 
 <Base
 	title="Independent review of digital and AI investment decisions"
-	description="Steven Yule, chartered civil engineer giving owners an independent read on digital and AI investment decisions in infrastructure and capital programmes."
+	description="Steven Yule, a chartered civil engineer in Dubai, giving infrastructure owners an independent read on digital and AI investment decisions across the GCC and UK."
 	schema={[website]}
 >
 	<h1 class="hero-title">

--- a/site/src/pages/notes/[...slug].astro
+++ b/site/src/pages/notes/[...slug].astro
@@ -21,12 +21,14 @@ const dateFormatter = new Intl.DateTimeFormat('en-GB', {
 });
 
 const isoDate = note.data.pubDate.toISOString().slice(0, 10);
+const isoUpdated = note.data.updatedDate?.toISOString().slice(0, 10);
 
 const article = {
 	'@type': 'Article',
 	headline: note.data.title,
 	description: note.data.description,
 	datePublished: isoDate,
+	...(isoUpdated ? { dateModified: isoUpdated } : {}),
 	author: { '@id': PERSON_ID },
 	mainEntityOfPage: new URL(Astro.url.pathname, Astro.site).href,
 };

--- a/site/src/pages/review/index.astro
+++ b/site/src/pages/review/index.astro
@@ -1,10 +1,34 @@
 ---
 import Base from '../../layouts/Base.astro';
+import { PERSON_ID } from '../../lib/schema';
+
+const service = {
+	'@type': 'Service',
+	'@id': 'https://okarthur.com/review/#service',
+	name: 'Independent review',
+	serviceType:
+		'Independent review of a digital or AI investment decision',
+	description:
+		'A second opinion on a proposed digital, data or AI investment in infrastructure. Fixed scope, a fixed end date, and one written opinion from someone with no stake in the outcome.',
+	url: 'https://okarthur.com/review/',
+	provider: { '@id': PERSON_ID },
+	areaServed: [
+		{ '@type': 'Country', name: 'United Arab Emirates' },
+		{ '@type': 'Country', name: 'United Kingdom' },
+		{ '@type': 'Place', name: 'Gulf Cooperation Council' },
+	],
+	audience: {
+		'@type': 'Audience',
+		audienceType:
+			'Infrastructure owners, developers and major capital programmes',
+	},
+};
 ---
 
 <Base
 	title="Independent review"
 	description="A second opinion on a digital or AI investment decision in infrastructure, before you commit. Fixed scope, fixed end date, one written opinion."
+	schema={[service]}
 >
 	<div class="page-head">
 		<h1 class="page-title">Independent review</h1>


### PR DESCRIPTION
Sharpens the homepage description and adds a Service node on the review page, plus knowsAbout on the Person, so search engines and AI retrieval systems can identify the person, the offer and the geography without guessing. Also adds an optional updatedDate/ dateModified path for notes, unused until a note sets it.