### PR TITLE
Add ICE Inside Infrastructure piece to Published elsewhere

### DIFF
--- a/site/src/pages/notes/index.astro
+++ b/site/src/pages/notes/index.astro
@@ -61,6 +61,10 @@ const isoDate = (date: Date) => date.toISOString().slice(0, 10);
 		<p>Selected writing and talks for other publications and institutions.</p>
 		<ul class="elsewhere-list">
 			<li>
+				<a href="https://www.ice.org.uk/news-views-insights/inside-infrastructure/not-every-slow-step-in-engineering-is-waste" target="_blank" rel="noopener noreferrer">The limits of efficiency: not every slow step in engineering is waste</a>
+				<span class="elsewhere-source">Institution of Civil Engineers, Inside Infrastructure</span>
+			</li>
+			<li>
 				<a href="https://www.ice.org.uk/events/recorded-lectures/beyond-engineering-digital-transformation-middle-east" target="_blank" rel="noopener noreferrer">How AI is shaping the built environment in the Middle East</a>
 				<span class="elsewhere-source">Institution of Civil Engineers, recorded lecture</span>
 			</li>


### PR DESCRIPTION
Adds the 13 July 2026 ICE Inside Infrastructure article as the first item in the Published elsewhere list on /notes/. Single file, no content collection change.