### PR TITLE
Reposition the site around three ways to commission the work

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -21,14 +21,17 @@ const path = Astro.url.pathname;
 
 const sections = [
 	{ href: '/about', label: 'About' },
-	{ href: '/review', label: 'Review' },
+	{ href: '/work', label: 'Work' },
 	{ href: '/notes', label: 'Notes' },
 	{ href: '/contact', label: 'Contact' },
 ];
 
-/** A section is current when the page is that section or lives beneath it. */
+/** A section is current when the page is that section or lives beneath it.
+ * /review keeps its own URL but belongs to Work in the nav. */
 const isCurrent = (href: string) =>
-	path === href || path.startsWith(`${href}/`);
+	path === href ||
+	path.startsWith(`${href}/`) ||
+	(href === '/work' && (path === '/review' || path.startsWith('/review/')));
 ---
 
 <html lang="en-GB">

--- a/site/src/lib/schema.ts
+++ b/site/src/lib/schema.ts
@@ -6,7 +6,7 @@ export const person = {
 	'@type': 'Person',
 	'@id': PERSON_ID,
 	name: 'Steven Yule',
-	jobTitle: 'Digital, data and infrastructure transformation director',
+	jobTitle: 'Independent adviser on digital and AI in infrastructure',
 	honorificSuffix: 'CEng FICE FCIHT MIAM',
 	url: 'https://okarthur.com',
 	email: 'steven@okarthur.com',

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Base from '../layouts/Base.astro';
 import { PERSON_ID } from '../lib/schema';
+import { getCollection } from 'astro:content';
 
 const website = {
 	'@type': 'WebSite',
@@ -10,13 +11,24 @@ const website = {
 	publisher: { '@id': PERSON_ID },
 };
 
+const allNotes = await getCollection('notes', ({ data }) => !data.draft);
+const [latest] = allNotes.sort(
+	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+);
+
+const dateFormatter = new Intl.DateTimeFormat('en-GB', {
+	day: 'numeric',
+	month: 'long',
+	year: 'numeric',
+});
+
 const gateways = [
 	{
-		href: '/review',
+		href: '/work',
 		label: 'What you can commission',
-		target: 'Independent review',
+		target: 'Work',
 		teaser:
-			'A second opinion on a digital or AI investment decision. Fixed scope, fixed end date, one written opinion.',
+			'Independent review of a decision, continuing advisory, and non-executive and board roles.',
 	},
 	{
 		href: '/notes',
@@ -36,20 +48,24 @@ const gateways = [
 ---
 
 <Base
-	title="Independent review of digital and AI investment decisions"
-	description="Steven Yule, a chartered civil engineer in Dubai, giving infrastructure owners an independent read on digital and AI investment decisions across the GCC and UK."
+	title="Steven Yule, independent advice on digital and AI in infrastructure"
+	description="Steven Yule, chartered civil engineer in Dubai. Independent review, advisory and board work on digital and AI decisions in infrastructure, across the GCC and UK."
 	schema={[website]}
 >
 	<h1 class="hero-title">
-		Independent review of digital and AI investment decisions.
+		Independent advice on digital and AI in infrastructure and capital
+		programmes.
 	</h1>
 	<p class="standfirst">
 		I'm Steven Yule, a chartered civil engineer working at director level in
-		digital, data and AI for infrastructure, across the GCC and UK. When an
-		owner is about to commit, to a supplier's proposal, a digital twin, a
-		handover, or a business case, I give them a written opinion from someone
-		with no stake in the outcome. Fixed scope, a fixed end date, one
-		document a board can act on.
+		digital, data and AI for infrastructure, across the GCC and the UK. Owners
+		bring me in when a digital or AI decision has to be made and everyone
+		holding the evidence stands to gain from the answer. What they get from me
+		is an opinion with nothing riding on it.
+	</p>
+	<p class="meta hero-credentials">
+		CEng FICE FCIHT MIAM. ICE UAE Country Representative and ICE Policy
+		Fellow.
 	</p>
 
 	<nav class="gateways reveal" aria-label="Main sections">
@@ -65,4 +81,13 @@ const gateways = [
 			))
 		}
 	</nav>
+
+	{
+		latest && (
+			<p class="meta hero-latest">
+				Latest note. <a href={`/notes/${latest.id}`}>{latest.data.title}</a>,{' '}
+				{dateFormatter.format(latest.data.pubDate)}.
+			</p>
+		)
+	}
 </Base>

--- a/site/src/pages/work/index.astro
+++ b/site/src/pages/work/index.astro
@@ -1,0 +1,106 @@
+---
+import Base from '../../layouts/Base.astro';
+import { PERSON_ID } from '../../lib/schema';
+
+const advisory = {
+	'@type': 'Service',
+	'@id': 'https://okarthur.com/work/#advisory',
+	name: 'Continuing advisory',
+	serviceType:
+		'Independent advisory on digital, data and AI in infrastructure',
+	description:
+		'Retained independent advice to infrastructure owners and leadership teams on digital, data and AI decisions and procurements, bought as a retainer or a defined block of days.',
+	url: 'https://okarthur.com/work/',
+	provider: { '@id': PERSON_ID },
+	areaServed: [
+		{ '@type': 'Country', name: 'United Arab Emirates' },
+		{ '@type': 'Country', name: 'United Kingdom' },
+		{ '@type': 'Place', name: 'Gulf Cooperation Council' },
+	],
+	audience: {
+		'@type': 'Audience',
+		audienceType:
+			'Infrastructure owners, developers and major capital programmes',
+	},
+};
+---
+
+<Base
+	title="Advisory, review and board work"
+	description="Three ways to commission independent judgement from Steven Yule on a digital or AI decision in infrastructure. A written review, continuing advisory, or a board appointment."
+	schema={[advisory]}
+>
+	<div class="page-head">
+		<h1 class="page-title">Work</h1>
+		<p class="lede">
+			Three ways to commission independent judgement on a digital or AI
+			decision.
+		</p>
+	</div>
+
+	<div class="prose reveal">
+		<p>
+			Every engagement here sells the same thing, judgement with no stake in
+			the answer. What varies is the shape it takes. A decision at a single
+			point takes a review. Where the decisions keep coming, it takes an
+			adviser who stays in the room, or a seat on the board.
+		</p>
+
+		<h2>Independent review</h2>
+		<p>
+			A second opinion on a specific decision, before you commit. A
+			supplier's proposal, a digital twin, a business case, a handover into
+			operation. Fixed scope and a fixed end date, agreed before work starts.
+			One written opinion, short enough for a board to read and specific
+			enough to act on. A fixed fee, proposed within two working days of a
+			first call.
+		</p>
+		<p>
+			<a href="/review/">The full scope of a review</a>, including what is
+			examined, what you receive, and what sits outside it.
+		</p>
+
+		<h2>Continuing advisory</h2>
+		<p>
+			Some decisions do not resolve in a single opinion. Where an owner or a
+			leadership team needs independent judgement available across months
+			rather than once, I work as a retained adviser. Client-side support
+			while a supplier delivers. A platform or integrator procurement that
+			needs its scope, evaluation criteria and contract shape set before it
+			goes to market. A digital or data strategy that needs challenging
+			before it is funded. A programme where someone has to be willing to say
+			the thing nobody in the room is paid to say.
+		</p>
+		<p>
+			Bought as a retainer or a defined block of days, agreed in advance. The
+			independence rule holds here as it does on a review. I take no delivery
+			work and no supplier-side work on anything I am advising on, and any
+			interest is declared before the engagement starts.
+		</p>
+
+		<h2>Board and non-executive</h2>
+		<p>
+			Boards are being asked to approve digital and AI investment at a scale
+			most of them cannot test, on evidence they are not equipped to
+			challenge. I take non-executive and advisory board appointments where
+			that is the gap. What I bring is a chartered engineer fluent in
+			digital, data and AI at board level, rather than a technologist who has
+			learned the vocabulary of governance.
+		</p>
+		<p>Private companies and advisory boards, in the UK and the UAE.</p>
+
+		<h2>Speaking and writing</h2>
+		<p>
+			Keynotes, panels, media comment and bylines on digital, data and AI in
+			infrastructure. Recent talks and published work are listed under <a
+				href="/notes/">Notes</a
+			>.
+		</p>
+
+		<h2>Start here</h2>
+		<p>
+			<a href="/contact/">Tell me the decision you are facing</a>, or the role
+			you are trying to fill.
+		</p>
+	</div>
+</Base>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -478,6 +478,20 @@ main {
 	text-wrap: pretty;
 }
 
+/* Post-nominals and appointments, and the pointer to the newest note. Both
+   lean on .meta for their voice and only add their own spacing. */
+.hero-credentials {
+	margin-top: var(--s-5);
+	max-width: 54ch;
+	line-height: 1.6;
+}
+
+.hero-latest {
+	margin-top: var(--s-6);
+	max-width: 54ch;
+	line-height: 1.6;
+}
+
 /* Editorial navigation: rows on a rule, not buttons on a grid. */
 .gateways {
 	margin-top: var(--s-9);


### PR DESCRIPTION
The site fronted a single service, Independent review, which framed the practice as one product rather than one person's judgement sold in three shapes. This adds a **Work** section that holds all three: the review, continuing advisory, and board and non-executive appointments.

## What changed

- **`Base.astro`** — nav swaps Review for Work. `/review/` keeps its own URL but now highlights Work in the nav, so the review reads as a page beneath the practice rather than a sibling of it.
- **`schema.ts`** — `jobTitle` becomes "Independent adviser on digital and AI in infrastructure".
- **`pages/work/index.astro`** (new) — the three offerings, plus speaking and writing. Links down into `/review/` for the full scope.
- **`pages/index.astro`** — leads with the judgement rather than the product. New title, H1 and standfirst, a muted credential line under the standfirst, a reworked first gateway, and a line pointing at the newest note.
- **`global.css`** — `.hero-credentials` and `.hero-latest`, which only add spacing on top of the existing `.meta` styling.

## Schema note

Only the advisory carries a `Service` node. A board seat is an appointment, not a service, and is deliberately not marked up as one — `/work/` emits exactly one `Service`.

## Verification

Build passes. No `TODO`/`PLACEHOLDER`/`lorem` in `dist/`, no `Capabilities` left in `src/`. `/work/index.html` builds with the advisory `Service` and no second one. Home title reads exactly `Steven Yule, independent advice on digital and AI in infrastructure | OkArthur` and links the most recent note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)