### PR TITLE
Bring About and Contact into line with the three offerings

### DIFF
--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -3,7 +3,7 @@ import Base from '../layouts/Base.astro';
 ---
 
 <Base
-	title="About"
+	title="About Steven Yule"
 	description="Steven Yule, chartered civil engineer and ICE fellow in Dubai, giving owners an independent read on digital and AI investment decisions in infrastructure."
 >
 	<div class="page-head">
@@ -39,10 +39,16 @@ import Base from '../layouts/Base.astro';
 			what at handover.
 		</p>
 		<p>
-			That work now usually takes one shape. An owner is about to commit,
-			to a supplier's proposal, a platform, a handover, and wants a second
-			opinion from someone with no stake in the outcome. That is what
-			the <a href="/review/">independent review</a> is.
+			That work is commissioned in three ways. An <a href="/review/"
+				>independent review</a
+			>, where an owner is about to commit and wants a written second
+			opinion from someone with no stake in the outcome. Continuing
+			advisory, where the judgement is needed across months rather than in
+			a single document. And non-executive and board roles, where the
+			challenge has to happen in the room. The review is the sharpest of the
+			three and the usual way in. What you can commission is set out under <a
+				href="/work/">Work</a
+			>.
 		</p>
 		<p>
 			My background spans transport, utilities, smart cities, the built

--- a/site/src/pages/contact.astro
+++ b/site/src/pages/contact.astro
@@ -29,11 +29,18 @@ import Base from '../layouts/Base.astro';
 			proposal within two working days.
 		</p>
 
-		<h2>Everything else</h2>
+		<h2>If you are considering continuing advisory</h2>
 		<p>
-			Advisory engagements, non-executive and board roles, speaking and
-			writing all reach the same address. For media comment on digital,
-			data and AI in infrastructure, mark it a press enquiry.
+			Tell me what is being decided or going to market over the coming
+			months, who is delivering it, and where you need someone independent
+			in the room. Again, roles rather than names.
+		</p>
+
+		<h2>Board, speaking and media</h2>
+		<p>
+			Non-executive and advisory board approaches, speaking invitations and
+			media comment all reach the same address. For press, mark it a press
+			enquiry.
 		</p>
 	</div>
 </Base>


### PR DESCRIPTION
Follow-on to #59. That PR built the Work page and the three-offering nav, but left About and Contact still describing a single-service practice.

## What changed

**`about.astro`** — the paragraph beginning "That work now usually takes one shape" said exactly that, which was true when the review was the only thing on sale and is not any more. It now names all three ways in and points at `/work/`, while keeping the review as the sharpest of them and the usual entry point. Title prop becomes "About Steven Yule"; the description prop is unchanged. The origin-note block is untouched.

**`contact.astro`** — "Everything else" was carrying two quite different enquiries. Advisory now gets its own section telling people what to bring to a first conversation, mirroring what the review section already did. Board, speaking and media keep the catch-all, since they genuinely do share one address. The Base props and the opening email/LinkedIn paragraph are unchanged.

## Verification

Build passes. `dist/about/index.html` title reads `About Steven Yule | OkArthur`, and `grep -r 'Everything else' src/` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)