### PR TITLE
Reach the media page from Work and the footer, not the nav

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -26,12 +26,15 @@ const sections = [
 	{ href: '/contact', label: 'Contact' },
 ];
 
-/** A section is current when the page is that section or lives beneath it.
- * /review keeps its own URL but belongs to Work in the nav. */
+/** Pages that keep their own URL but belong to Work in the nav. */
+const workPages = ['/review', '/media'];
+
+/** A section is current when the page is that section or lives beneath it. */
 const isCurrent = (href: string) =>
 	path === href ||
 	path.startsWith(`${href}/`) ||
-	(href === '/work' && (path === '/review' || path.startsWith('/review/')));
+	(href === '/work' &&
+		workPages.some((p) => path === p || path.startsWith(`${p}/`)));
 ---
 
 <html lang="en-GB">
@@ -116,6 +119,7 @@ const isCurrent = (href: string) =>
 					<p>&copy; 2026 OkArthur</p>
 					<nav class="footer-nav" aria-label="Footer">
 						<a href="mailto:steven@okarthur.com">steven@okarthur.com</a>
+						<a href="/media">Media</a>
 						<a href="/privacy">Privacy</a>
 						<a href="/terms">Terms</a>
 					</nav>

--- a/site/src/pages/work/index.astro
+++ b/site/src/pages/work/index.astro
@@ -94,6 +94,8 @@ const advisory = {
 			Keynotes, panels, media comment and bylines on digital, data and AI in
 			infrastructure. Recent talks and published work are listed under <a
 				href="/notes/">Notes</a
+			>. Biography, photo and topics for comment are on the <a href="/media/"
+				>media page</a
 			>.
 		</p>
 


### PR DESCRIPTION
Follow-on to #63, which added the media page but left it reachable only from Contact.

Media is now reachable three ways — Work, Contact, and the footer — **without** taking a fifth slot in the top nav.

## Why not the nav

Review already keeps its own URL while belonging to Work in the nav. Media is a smaller thing than Review, so promoting it to a top-level item would have put press coverage above the thing the site sells, and broken the rule that the nav names sections rather than services. It follows Review's pattern instead.

## What changed

- **`Base.astro`** — `/media` added to the footer, next to Privacy and Terms, where press pages conventionally live. `/media/` now highlights Work in the nav, exactly as `/review/` does. The two pages that borrow Work's nav entry are a list now rather than a special case, since that is what they have become.
- **`work/index.astro`** — the "Speaking and writing" section, which pointed only at Notes, now also points at the media page. That is where someone looking for a biography or a photo would actually look.

## Verification

Build passes, 13 pages. Confirmed on the built output: `/media/` highlights Work, `/review/` still does, the top nav is still four items with no Media in it, the footer carries Media, and Work links to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)