### PR TITLE
Make the Person entity separable from other people of the same name

### DIFF
--- a/site/src/lib/schema.ts
+++ b/site/src/lib/schema.ts
@@ -6,7 +6,7 @@ export const person = {
 	'@type': 'Person',
 	'@id': PERSON_ID,
 	name: 'Steven Yule',
-	jobTitle: 'Independent adviser on digital and AI in infrastructure',
+	jobTitle: 'Chartered civil engineer',
 	honorificSuffix: 'CEng FICE FCIHT MIAM',
 	url: 'https://okarthur.com',
 	image: 'https://okarthur.com/steven-yule.jpg',
@@ -17,6 +17,28 @@ export const person = {
 		addressCountry: 'AE',
 	},
 	sameAs: ['https://www.linkedin.com/in/stevenyule'],
+	memberOf: [
+		{
+			'@type': 'Organization',
+			name: 'Institution of Civil Engineers',
+			url: 'https://www.ice.org.uk',
+		},
+		{
+			'@type': 'Organization',
+			name: 'Chartered Institution of Highways and Transportation',
+			url: 'https://www.ciht.org.uk',
+		},
+		{
+			'@type': 'Organization',
+			name: 'Institute of Asset Management',
+			url: 'https://theiam.org',
+		},
+		{
+			'@type': 'Organization',
+			name: 'Worshipful Company of Engineers',
+			url: 'https://www.engineerscompany.org.uk',
+		},
+	],
 	knowsAbout: [
 		'Digital twins',
 		'Asset information management',
@@ -24,5 +46,9 @@ export const person = {
 		'Artificial intelligence in infrastructure',
 		'Capital programme delivery',
 		'Whole-life asset management',
+		'Digital and AI investment appraisal',
+		'Technology procurement for infrastructure owners',
+		'Independent technical review',
+		'Digital twin assurance',
 	],
 };


### PR DESCRIPTION
Strengthens the Person JSON-LD in `site/src/lib/schema.ts` so the entity is
distinguishable from other people called Steven Yule. One file changed.

## Changes

**`jobTitle`** — was *Independent adviser on digital and AI in infrastructure*,
now **Chartered civil engineer**. `jobTitle` is a singular field, and the
advisory framing, while true, is situational. The profession is the claim that
holds under every scenario, including the full-time director role.

**`memberOf`** — new. Four professional bodies, each an `Organization` with a
name and its official url, so a consumer can resolve the body rather than infer
it from an acronym: Institution of Civil Engineers, Chartered Institution of
Highways and Transportation, Institute of Asset Management, Worshipful Company
of Engineers. These are memberships, not alternative identities, so they are
deliberately kept out of `sameAs`. No `Organization` node is created for
OkArthur.

**`knowsAbout`** — the six existing topics are unchanged; four are added
(digital and AI investment appraisal, technology procurement for infrastructure
owners, independent technical review, digital twin assurance), for ten in total.

## Verification

Verified against the built output, not the source: `site/dist/index.html` was
parsed, the Person JSON-LD extracted, and asserted on.

- `jobTitle` is exactly `Chartered civil engineer`
- `memberOf` has exactly four `Organization` entries, each with a name and url
- `knowsAbout` has exactly ten entries, with all six originals intact
- no node anywhere in `site/dist` has `@type: Organization` with an OkArthur name
- none of the four memberOf urls leak into `sameAs`

The four urls were resolved over HTTP: ciht.org.uk, theiam.org and
engineerscompany.org.uk each return 200. ice.org.uk returns 403 to automated
clients, which is the documented anti-bot behaviour that already puts it in
lychee's exclude list.

**On linkcheck:** lychee does not check these four urls at all. It treats
`<script>` bodies as verbatim content and skips them unless `--include-verbatim`
is passed, which CI does not pass. Confirmed by running lychee with the exact CI
arguments over a build of `origin/main` and over this branch: both see 298 links,
13 successful, 58 excluded — byte-identical. This change adds no link that
linkcheck can see, so it cannot break that check.