### PR TITLE
Bring CLAUDE.md in line with the repo, and settle "sixteen years"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,21 +15,40 @@ or `requirements.txt`, they are stale and should be deleted.
 
 ## Commands
 
-Run these inside `site/`:
+Every npm command runs inside `site/`, never at the repository root. There
+is no root `package.json`, so `npm install` or `npm run build` at the root
+will not fail loudly; it will just do the wrong thing.
 
     npm install
     npm run dev       local dev server
     npm run build     writes site/dist
     npm run preview   serve the built site
 
+The Open Graph card is generated, not hand-edited, and is not part of
+`npm run build`. Regenerate it only when the card design changes:
+
+    node scripts/og-card.mjs    writes site/public/og-default-v3.png
+
+That script is the only reason `site/package.json` carries
+devDependencies. `@resvg/resvg-js`, `subset-font` and `wawoff2` are pinned
+to exact versions and are used by the card generator alone. Nothing in the
+site's runtime imports them, and `npm run build` does not need them, so do
+not "tidy them away" as unused.
+
 ## Layout
 
-    site/src/pages/            routes (index, about, review, contact,
-                               privacy, terms, notes, 404)
+    site/src/pages/            routes (index, about, work, review, media,
+                               contact, privacy, terms, notes, rss.xml,
+                               404)
     site/src/content/notes/    notes collection, markdown, schema in
                                site/src/content.config.ts
     site/src/lib/schema.ts     shared JSON-LD Person/WebSite definitions
+    site/scripts/og-card.mjs   generates the Open Graph card, run by hand
     site/public/               copied verbatim into dist
+
+`notes` is two files: `notes/index.astro` for the list and
+`notes/[...slug].astro` for each note. `work`, `review` and `media` are
+each an `index.astro` inside their own directory.
 
 `site/public/` holds `CNAME`, `humans.txt`, `robots.txt`, `llms.txt`,
 fonts, favicons, and `.well-known/security.txt`. Astro copies dotfiles and
@@ -83,6 +102,13 @@ The public contact address is steven@okarthur.com. `hello@okarthur.com` is
 wrong wherever it appears.
 
 `site/public/.well-known/security.txt` is the real one.
+
+`site/public/og-default-v2.png` must not be deleted, even though nothing in
+`site/src` references it any more. The live card is `og-default-v3.png`, so
+v2 looks like a dead asset and reads as safe to remove. It is not. LinkedIn
+caches share renders against the absolute image URL, and posts already in
+circulation still point at v2. Deleting it breaks the card on every one of
+them. The same goes for any future v4: retire the reference, keep the file.
 
 See `CARRYOVER.md` for copy that was drafted rather than written, and for
 the open issues that go with it.

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -14,7 +14,7 @@ import Base from '../layouts/Base.astro';
 		<p>
 			I'm Steven Yule, a chartered civil engineer and a digital, data and AI
 			leader working at director level in infrastructure, based in Dubai.
-			I've spent more than sixteen years across the UAE, the wider GCC and
+			I've spent sixteen years across the UAE, the wider GCC and
 			the UK on the same problem, making technology useful once it meets a
 			live capital programme.
 		</p>


### PR DESCRIPTION
Two files: `CLAUDE.md` and `site/src/pages/about.astro`.

## CLAUDE.md

Corrected against the repository as it is, not as memory had it.

**Route list** was missing two pages and a feed. It now reads: index, about,
work, review, media, contact, privacy, terms, notes, rss.xml, 404 — with a note
that `notes` is a list page plus a `[...slug]` route, and that `work`, `review`
and `media` are each an `index.astro` in their own directory.

**`scripts/og-card.mjs`** was undocumented. It generates the Open Graph card,
runs by hand (`node scripts/og-card.mjs`), and is not part of `npm run build`.

**The three devDependencies** now have a stated reason to exist. `@resvg/resvg-js`,
`subset-font` and `wawoff2` are pinned and used by the card generator alone —
nothing in the site's runtime imports them. Anyone auditing for unused packages
would have removed them and silently broken the card generator.

**npm commands run in `site/`, never at the repository root.** There is no root
`package.json`, so a root-level `npm install` doesn't fail loudly, it just does
the wrong thing.

**`og-default-v2.png` must not be deleted.** This is the trap most worth writing
down: the live card is `og-default-v3.png` and nothing in `site/src` references
v2 any more, so it scans as a dead asset. LinkedIn caches share renders against
the absolute image URL, and posts already in circulation still point at v2.
Deleting it breaks the card on every one of them.

## Copy

Three occurrences of "sixteen years" exist in `src/`. Only one was inconsistent:

- `about.astro` said "more than sixteen years" → now "sixteen years"
- `media/index.astro` already said "sixteen years" (the standard biography)
- `review/index.astro` already said "For sixteen years" — "For" is the sentence's
  preposition, not a variant of the claim, so it is untouched

## Verification

- `npm run build` passes from inside `site/` — 13 pages
- `grep -r "more than sixteen" src/` returns nothing
- the rendered `dist/about/index.html` reads "I've spent sixteen years across the
  UAE, the wider GCC and the UK…"
- the documented route list matches the routes the build actually emits