### PR TITLE
Meta descriptions within Bing's limit, and About names the person

### DIFF
--- a/site/src/content/notes/what-makes-a-digital-twin-worth-relying-on.md
+++ b/site/src/content/notes/what-makes-a-digital-twin-worth-relying-on.md
@@ -1,6 +1,6 @@
 ---
 title: "What makes a digital twin worth relying on"
-description: "What it takes for an owner to rely on a digital twin for a specific decision, and why procurement sets the conditions for reliance rather than guaranteeing it."
+description: "What it takes for an owner to rely on a digital twin for a decision, and why procurement sets the conditions for reliance rather than guaranteeing it."
 pubDate: 2026-07-11
 ---
 

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -4,10 +4,10 @@ import Base from '../layouts/Base.astro';
 
 <Base
 	title="About Steven Yule"
-	description="Steven Yule, chartered civil engineer and ICE fellow in Dubai, giving owners an independent read on digital and AI investment decisions in infrastructure."
+	description="Steven Yule, chartered civil engineer in Dubai. Sixteen years making digital and AI useful on live capital programmes, across the GCC and the UK."
 >
 	<div class="page-head">
-		<h1 class="page-title">About OkArthur</h1>
+		<h1 class="page-title">About Steven Yule</h1>
 	</div>
 
 	<div class="prose reveal">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -49,7 +49,7 @@ const gateways = [
 
 <Base
 	title="Steven Yule, independent advice on digital and AI in infrastructure"
-	description="Steven Yule, chartered civil engineer in Dubai. Independent review, advisory and board work on digital and AI decisions in infrastructure, across the GCC and UK."
+	description="Steven Yule, chartered civil engineer in Dubai. Independent advice on digital and AI in infrastructure. Review, advisory and board work."
 	schema={[website]}
 >
 	<h1 class="hero-title">

--- a/site/src/pages/work/index.astro
+++ b/site/src/pages/work/index.astro
@@ -27,7 +27,7 @@ const advisory = {
 
 <Base
 	title="Advisory, review and board work"
-	description="Three ways to commission independent judgement from Steven Yule on a digital or AI decision in infrastructure. A written review, continuing advisory, or a board appointment."
+	description="Independent judgement from Steven Yule on a digital or AI decision in infrastructure. A written review, continuing advisory, or a board appointment."
 	schema={[advisory]}
 >
 	<div class="page-head">


### PR DESCRIPTION
## What

Rewrites four meta descriptions to sit under 155 characters, and changes the About h1 to name the person.

## Why

Bing truncates meta descriptions at roughly 155 characters. Three of the four pages were over:

| Route | Before | After |
| --- | --- | --- |
| `/` | 161 | 136 |
| `/about/` | 154 | 145 |
| `/work/` | 173 | 148 |
| `/notes/what-makes-a-digital-twin-worth-relying-on/` | 159 | 150 |

The About page carried `title="About Steven Yule"` but an h1 of "About OkArthur". The page is about the person, so the h1 now matches the title.

## Verified

Against the built output in `site/dist`, not the source. All 13 built pages carry a meta description and none exceeds 155 characters; the longest is `/contact/` at 152, which was already within the limit and is untouched. The built About page renders `<title>About Steven Yule | OkArthur</title>` and `<h1>About Steven Yule</h1>`.

The JSON-LD `Service` description in `work/index.astro` is a different field and is deliberately unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)