### PR TITLE
Fail CI when a meta description overruns Bing's limit

### DIFF
--- a/.github/workflows/astro-ci.yml
+++ b/.github/workflows/astro-ci.yml
@@ -17,6 +17,11 @@ jobs:
         working-directory: site
       - run: npm run build
         working-directory: site
+      # A step of build, not a job of its own: it needs the same dist the build
+      # just produced, and folding it in keeps the required checks at three.
+      - name: Meta descriptions within Bing's 155 character limit
+        run: npm run check:meta
+        working-directory: site
 
   gitleaks:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ will not fail loudly; it will just do the wrong thing.
     npm run dev       local dev server
     npm run build     writes site/dist
     npm run preview   serve the built site
+    npm run check:meta  asserts meta descriptions fit Bing's 155 characters,
+                        reads site/dist, so run it after a build
 
 The Open Graph card is generated, not hand-edited, and is not part of
 `npm run build`. Regenerate it only when the card design changes:
@@ -44,6 +46,7 @@ not "tidy them away" as unused.
                                site/src/content.config.ts
     site/src/lib/schema.ts     shared JSON-LD Person/WebSite definitions
     site/scripts/og-card.mjs   generates the Open Graph card, run by hand
+    site/scripts/check-meta.mjs  meta description length check, run in CI
     site/public/               copied verbatim into dist
 
 `notes` is two files: `notes/index.astro` for the list and
@@ -81,8 +84,16 @@ the old page.
 ## CI
 
 `.github/workflows/astro-ci.yml` runs on pull requests and on pushes to
-`rebuild/astro`. Jobs: `build`, `gitleaks`, `linkcheck`. These three are
-the required status checks on `main`.
+`main`. Jobs: `build`, `gitleaks`, `linkcheck`. These three are the
+required status checks on `main`.
+
+`build` also runs `npm run check:meta` after the build, which fails the job
+if any page's meta description is missing or runs past 155 characters, the
+point at which Bing truncates. It is a step of `build` rather than a job of
+its own so that it can read the dist that build just produced, and so that
+the required checks stay at three. Adding a fourth job would mean editing
+branch protection, and the check would have to build the site a second time
+to have anything to read.
 
 `linkcheck` runs lychee over `site/dist`. Its `--exclude` flags are
 load-bearing and documented in the workflow: our own domain (canonical

--- a/site/package.json
+++ b/site/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "check:meta": "node scripts/check-meta.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/site/scripts/check-meta.mjs
+++ b/site/scripts/check-meta.mjs
@@ -1,0 +1,102 @@
+/**
+ * Fails if any built page's meta description is missing or too long.
+ *
+ *     npm run build && npm run check:meta
+ *
+ * Bing truncates meta descriptions at roughly 155 characters, which is the
+ * tighter of the two limits that matter to us; Google's is longer and varies.
+ * A description that overruns is not an error anyone sees locally, so it went
+ * unnoticed until three of five pages were over. Hence a check.
+ *
+ * This reads dist rather than src on purpose. The description reaches the page
+ * by three different routes — a prop on index.astro and about.astro, a prop on
+ * work/index.astro, and frontmatter on each note, threaded through
+ * notes/[...slug].astro — and a source-level check would have to know all
+ * three, and would miss a fourth added later. The built HTML is the only place
+ * every route converges, and it is what a crawler actually reads.
+ *
+ * Entities are decoded before counting so that an apostrophe escaped as &#39;
+ * counts as the one character a crawler sees, not six.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const DIST = join(here, '..', 'dist');
+
+const LIMIT = 155;
+
+function htmlFiles(dir) {
+	const out = [];
+	for (const entry of readdirSync(dir)) {
+		const full = join(dir, entry);
+		if (statSync(full).isDirectory()) out.push(...htmlFiles(full));
+		else if (entry.endsWith('.html')) out.push(full);
+	}
+	return out;
+}
+
+const decode = (s) =>
+	s
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/&apos;/g, "'")
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>')
+		.replace(/&nbsp;/g, ' ')
+		.replace(/&amp;/g, '&');
+
+let files;
+try {
+	files = htmlFiles(DIST).sort();
+} catch {
+	console.error('No dist directory. Run `npm run build` first.');
+	process.exit(1);
+}
+
+if (files.length === 0) {
+	console.error('dist contains no .html files. Did the build succeed?');
+	process.exit(1);
+}
+
+const pages = files.map((file) => {
+	const html = readFileSync(file, 'utf8');
+	const m = html.match(/<meta\s+name="description"\s+content="([^"]*)"\s*\/?>/i);
+	return { path: relative(DIST, file), desc: m ? decode(m[1]) : null };
+});
+
+pages.sort((a, b) => (b.desc?.length ?? -1) - (a.desc?.length ?? -1));
+
+for (const { path, desc } of pages) {
+	if (desc === null) {
+		console.log(`  missing  ---  ${path}`);
+		continue;
+	}
+	const n = [...desc].length;
+	console.log(`  ${n > LIMIT ? 'OVER' : '  ok'}  ${String(n).padStart(3)}  ${path}`);
+}
+
+const missing = pages.filter((p) => p.desc === null);
+const over = pages.filter((p) => p.desc && [...p.desc].length > LIMIT);
+
+for (const { path } of missing) {
+	console.error(`\n${path} has no meta description.`);
+}
+for (const { path, desc } of over) {
+	console.error(
+		`\n${path} has a ${[...desc].length} character meta description, ` +
+			`${LIMIT} is the limit:\n  ${desc}`
+	);
+}
+
+if (missing.length || over.length) {
+	console.error(
+		`\nFailed: ${over.length} over ${LIMIT} characters, ${missing.length} missing.`
+	);
+	process.exit(1);
+}
+
+console.log(
+	`\n${pages.length} pages checked, none over ${LIMIT} characters.`
+);


### PR DESCRIPTION
Follows #67, which fixed four overlong meta descriptions. This stops them drifting back.

## What

`site/scripts/check-meta.mjs` reads every `.html` in `site/dist`, extracts the `content` of `<meta name="description">`, and fails if any page is missing one or runs past 155 characters — the point at which Bing truncates. Wired up as `npm run check:meta`.

## Why it reads dist, not src

A description reaches a page by more than one route: a `Base` prop on `index.astro`, `about.astro` and `work/index.astro`, and note frontmatter threaded through `notes/[...slug].astro`. A source-level check would have to know every route, and would miss the next one added. The built HTML is where they converge, and it is what a crawler actually reads.

Entities are decoded before counting, so an apostrophe escaped as `&#39;` counts as the one character a crawler sees rather than six.

## Why a step, not a job

It runs inside the existing `build` job, after `npm run build`. A job of its own would have to build the site a second time to have any `dist` to read, and would need a branch-protection edit to become required. As a step it inherits `build`'s required status. The required checks on `main` stay at three.

## Verified

Passes on the current tree, 13 pages checked, longest is `/contact/` at 152. Both failure branches were exercised by doctoring `dist`: a padded 159-character description on About, and a stripped one on Terms. It caught both and exited 1.

## Also

Corrects the CI section of `CLAUDE.md`, which claimed the workflow ran on pushes to `rebuild/astro`. It runs on pushes to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)