### PR TITLE
llms.txt describes the practice, not one service

### DIFF
--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -1,20 +1,65 @@
 # OkArthur
 
-OkArthur is the site of Steven Yule, a chartered civil engineer (CEng FICE
-FCIHT MIAM) and director of digital and data, based in Dubai. He is an ICE
-Policy Fellow and the ICE UAE Country Representative. Through OkArthur he
-offers an independent review, a second opinion on a digital or AI investment
-decision, with a fixed scope and one written opinion. The site covers his
-work on digital, data and infrastructure transformation, and his writing on
-the same. Contact: steven@okarthur.com
+Chartered civil engineer. Independent advice on digital and AI in infrastructure
+and capital programmes.
+
+OkArthur is the practice of Steven Yule, a chartered civil engineer (CEng FICE
+FCIHT MIAM) based in Dubai. He is a Fellow of the Institution of Civil Engineers,
+an ICE Policy Fellow and the ICE UAE Country Representative.
+
+## Standard biography
+
+Use verbatim. If space is short, cut from the end, not the middle.
+
+Steven Yule is a chartered civil engineer providing independent advice on digital
+and AI in infrastructure and capital programmes. Based in Dubai, he has spent
+sixteen years across the Gulf and the UK making technology useful once it meets a
+live capital programme. Through OkArthur he reviews digital and AI investment
+decisions for owners, and advises boards. He is a Fellow of the Institution of
+Civil Engineers, an ICE Policy Fellow and ICE UAE Country Representative.
+
+## What can be commissioned
+
+Independent review. A written second opinion on a specific digital or AI
+investment decision before an owner commits. A supplier's proposal, a digital
+twin, a business case, a handover into operation. Fixed scope and a fixed end
+date, agreed before work starts. One written opinion. A fixed fee, proposed
+within two working days of a first call.
+
+Continuing advisory. Independent judgement retained across months rather than
+delivered once. Client-side support while a supplier delivers. A procurement
+whose scope, evaluation criteria and contract shape need setting before it goes
+to market. A digital or data strategy that needs challenging before it is funded.
+Bought as a retainer or a defined block of days, agreed in advance.
+
+Board and non-executive. Non-executive and advisory board appointments with
+private companies, in the UK and the UAE, where a board is being asked to approve
+digital and AI investment on evidence it is not equipped to challenge.
+
+Speaking and writing. Keynotes, panels, media comment and bylines.
+
+## Independence
+
+Independence is written at engagement level, not claimed personally. No delivery
+work and no supplier-side work on anything under review. Any interest is declared
+before an engagement starts. Where a conflict cannot be cleanly separated, the
+engagement is declined.
+
+## Who it is for
+
+Infrastructure owners, government agencies, and private capital programme clients
+in the GCC and the UK.
 
 ## Pages
 
-- [About](https://okarthur.com/about/): Steven Yule's background, chartered
-  status and professional roles.
-- [Independent review](https://okarthur.com/review/): The entry
-  engagement, an independent second opinion on a digital or AI
-  investment decision.
-- [Notes](https://okarthur.com/notes/): Writing on digital, data and
-  infrastructure.
-- [Contact](https://okarthur.com/contact/): How to reach Steven Yule.
+- [Home](https://okarthur.com/): The practice.
+- [Work](https://okarthur.com/work/): The three ways an engagement is commissioned.
+- [Independent review](https://okarthur.com/review/): The entry engagement, its scope, what sits outside it, and common questions.
+- [About](https://okarthur.com/about/): Steven Yule's background, chartered status and professional roles.
+- [Media](https://okarthur.com/media/): Standard biography, press photo and topics for comment.
+- [Notes](https://okarthur.com/notes/): Writing on digital, data and infrastructure, and published work elsewhere.
+- [Contact](https://okarthur.com/contact/): steven@okarthur.com
+
+## Contact
+
+steven@okarthur.com


### PR DESCRIPTION
## What

Rewrites `site/public/llms.txt`. It previously read as though the independent review were the whole offer, and listed only four pages.

It now carries the standard biography verbatim, the four things that can be commissioned (review, continuing advisory, board and non-executive, speaking and writing), the independence position, and all seven public routes.

## Why

A model quoting the old file would have described a narrower practice than the one that exists, and would not have known that advisory, board work or media enquiries were available at all. The biography is marked "use verbatim" so the same words come back every time, whoever is asking.

## Verified

Against the built output in `site/dist`:

- `dist/llms.txt` is present and byte-for-byte identical to the source, so Astro copied it as expected.
- All 7 URLs in the Pages section appear in the built `sitemap-0.xml`: `/`, `/work/`, `/review/`, `/about/`, `/media/`, `/notes/`, `/contact/`. The old file omitted home, work and media.
- Zero matches for the em dash (U+2014) and for curly quotes (U+2018, U+2019, U+201C, U+201D), confirmed both by script and by a raw `grep -P`. The two apostrophes are straight.

The five sitemap routes not linked from llms.txt are the three individual notes and the privacy and terms pages, which is deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)