### PR TITLE
Fail CI when llms.txt points at a route that does not exist

### DIFF
--- a/.github/workflows/astro-ci.yml
+++ b/.github/workflows/astro-ci.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Meta descriptions within Bing's 155 character limit
         run: npm run check:meta
         working-directory: site
+      # lychee does not cover llms.txt: it reads the HTML, and our own domain is
+      # excluded from it. Nothing else links these URLs, so a renamed route
+      # would rot the file silently.
+      - name: llms.txt links point at routes that exist
+        run: npm run check:llms
+        working-directory: site
 
   gitleaks:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,8 @@ will not fail loudly; it will just do the wrong thing.
     npm run preview   serve the built site
     npm run check:meta  asserts meta descriptions fit Bing's 155 characters,
                         reads site/dist, so run it after a build
+    npm run check:llms  asserts every URL in llms.txt is a real route, also
+                        reads site/dist, so run it after a build
 
 The Open Graph card is generated, not hand-edited, and is not part of
 `npm run build`. Regenerate it only when the card design changes:
@@ -47,6 +49,7 @@ not "tidy them away" as unused.
     site/src/lib/schema.ts     shared JSON-LD Person/WebSite definitions
     site/scripts/og-card.mjs   generates the Open Graph card, run by hand
     site/scripts/check-meta.mjs  meta description length check, run in CI
+    site/scripts/check-llms.mjs  llms.txt link check, run in CI
     site/public/               copied verbatim into dist
 
 `notes` is two files: `notes/index.astro` for the list and
@@ -94,6 +97,15 @@ its own so that it can read the dist that build just produced, and so that
 the required checks stay at three. Adding a fourth job would mean editing
 branch protection, and the check would have to build the site a second time
 to have anything to read.
+
+`build` also runs `npm run check:llms`, which fails the job if a URL in the
+Pages section of `llms.txt` is not a route in the built sitemap. `linkcheck`
+does not cover this: lychee reads the HTML in `dist`, and okarthur.com is
+excluded from it in any case. Nothing else in the build links these URLs, so
+without the check a renamed route leaves `llms.txt` pointing at a 404 and
+nothing says so. The reverse is not asserted, because plenty of routes
+belong in the sitemap and not in `llms.txt`: the individual notes, privacy,
+terms.
 
 `linkcheck` runs lychee over `site/dist`. Its `--exclude` flags are
 load-bearing and documented in the workflow: our own domain (canonical

--- a/site/package.json
+++ b/site/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "check:llms": "node scripts/check-llms.mjs",
     "check:meta": "node scripts/check-meta.mjs",
     "preview": "astro preview",
     "astro": "astro"

--- a/site/scripts/check-llms.mjs
+++ b/site/scripts/check-llms.mjs
@@ -1,0 +1,77 @@
+/**
+ * Fails if a URL in the built llms.txt does not exist on the site.
+ *
+ *     npm run build && npm run check:llms
+ *
+ * llms.txt is a hand-written file of hand-written links, and nothing else in
+ * the build refers to it. Rename a route and every other reference to it moves
+ * with the rename or breaks the build; llms.txt just goes quietly stale, and
+ * the first thing to notice is a model citing a URL that 404s.
+ *
+ * lychee does not cover this. It is pointed at the HTML in dist, and our own
+ * domain is excluded from it anyway, because canonical tags point at routes
+ * that do not exist on the live site until after the merge that adds them.
+ * The sitemap is the honest local answer to "what routes exist", since Astro
+ * generates it from the pages it actually built.
+ *
+ * Only the Pages section is checked. Prose elsewhere in the file may name a
+ * URL without linking it, and the contact address is not a route.
+ *
+ * The reverse is deliberately not asserted. Plenty of routes belong in the
+ * sitemap and not in llms.txt: the individual notes, privacy, terms. They are
+ * listed as information at the end, not as failures.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const DIST = join(here, '..', 'dist');
+
+let llms, sitemap;
+try {
+	llms = readFileSync(join(DIST, 'llms.txt'), 'utf8');
+	sitemap = readFileSync(join(DIST, 'sitemap-0.xml'), 'utf8');
+} catch {
+	console.error('Missing dist/llms.txt or dist/sitemap-0.xml. Run `npm run build` first.');
+	process.exit(1);
+}
+
+const pages = llms.split(/^## /m).find((s) => s.startsWith('Pages'));
+if (!pages) {
+	console.error('No "## Pages" section in dist/llms.txt.');
+	process.exit(1);
+}
+
+const linked = [...pages.matchAll(/\]\((https?:\/\/[^)]+)\)/g)].map((m) => m[1]);
+const routes = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+
+if (linked.length === 0) {
+	console.error('The Pages section of dist/llms.txt links to nothing. Expected links.');
+	process.exit(1);
+}
+
+for (const url of linked) {
+	console.log(`  ${routes.includes(url) ? '  ok' : 'GONE'}  ${url}`);
+}
+
+const gone = linked.filter((u) => !routes.includes(u));
+
+const unlinked = routes.filter((u) => !linked.includes(u));
+if (unlinked.length) {
+	console.log(`\n  Not linked from llms.txt, which is allowed:`);
+	for (const u of unlinked) console.log(`    ${u}`);
+}
+
+if (gone.length) {
+	console.error(
+		`\nFailed: ${gone.length} URL(s) in llms.txt are not routes on this site:`
+	);
+	for (const u of gone) console.error(`  ${u}`);
+	console.error('\nEither the route was renamed, or the link is a typo.');
+	process.exit(1);
+}
+
+console.log(
+	`\n${linked.length} of ${linked.length} URLs in llms.txt exist in the sitemap.`
+);


### PR DESCRIPTION
Follows #69, which rewrote `llms.txt`. This stops it rotting.

## Why

`llms.txt` is hand-written links to routes that nothing else in the build refers to. Rename a route and every other reference to it either moves with the rename or breaks the build. `llms.txt` just goes quietly stale, and the first thing to notice is a model citing a URL that 404s.

`linkcheck` does not close this gap. lychee reads the HTML in `dist`, and `okarthur.com` is excluded from it anyway, because canonical tags point at routes that do not exist on the live site until the merge that adds them.

## What

`site/scripts/check-llms.mjs` asserts that every URL in the Pages section of the built `llms.txt` appears as a `<loc>` in the built `sitemap-0.xml`. The sitemap is the honest local answer to "which routes exist", since Astro generates it from the pages it actually built.

Runs as `npm run check:llms`, as a step of the existing `build` job — same reasoning as `check:meta`: it needs the dist that build just produced, and the required checks on `main` stay at three.

## What it deliberately does not assert

The reverse. Plenty of routes belong in the sitemap and not in `llms.txt` — the three individual notes, privacy, terms. They are printed as information, not treated as failures.

## Verified

Passes on the current tree, 7 of 7 URLs found. The failure path was exercised by renaming `/review/` to `/second-opinion/` in the built sitemap, simulating a renamed route that `llms.txt` was not updated for: the check flagged `https://okarthur.com/review/` as `GONE` and exited 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)