### PR TITLE
Homepage title within Bing's 70-character ceiling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,9 @@ will not fail loudly; it will just do the wrong thing.
     npm run dev       local dev server
     npm run build     writes site/dist
     npm run preview   serve the built site
-    npm run check:meta  asserts meta descriptions fit Bing's 155 characters,
-                        reads site/dist, so run it after a build
+    npm run check:meta  asserts titles fit Bing's 70 characters and meta
+                        descriptions its 155, reads site/dist, so run it
+                        after a build
 
 The Open Graph card is generated, not hand-edited, and is not part of
 `npm run build`. Regenerate it only when the card design changes:
@@ -88,12 +89,21 @@ the old page.
 required status checks on `main`.
 
 `build` also runs `npm run check:meta` after the build, which fails the job
-if any page's meta description is missing or runs past 155 characters, the
-point at which Bing truncates. It is a step of `build` rather than a job of
-its own so that it can read the dist that build just produced, and so that
-the required checks stay at three. Adding a fourth job would mean editing
-branch protection, and the check would have to build the site a second time
-to have anything to read.
+if a page's title or meta description is missing or overruns Bing's limits,
+70 characters and 155. It also asserts that `og:title` agrees with `<title>`
+on every page, that `og:site_name` reads OkArthur, and that the brand suffix
+is present everywhere except the home page. It is a step of `build` rather
+than a job of its own so that it can read the dist that build just produced,
+and so that the required checks stay at three. Adding a fourth job would mean
+editing branch protection, and the check would have to build the site a
+second time to have anything to read.
+
+`Seo.astro` appends `" | OkArthur"` to every title. A page that passes
+`titleIsComplete` skips the suffix and supplies its whole title instead. The
+home page is the only page that does, because with the suffix its title ran
+to 78 characters. The prop governs `<title>` and `og:title` together, and
+that is deliberate: a page is called one thing, not two. Nothing is lost from
+a share unfurl, because `og:site_name` still carries the brand.
 
 `linkcheck` runs lychee over `site/dist`. Its `--exclude` flags are
 load-bearing and documented in the workflow: our own domain (canonical

--- a/site/scripts/check-meta.mjs
+++ b/site/scripts/check-meta.mjs
@@ -1,21 +1,29 @@
 /**
- * Fails if any built page's meta description is missing or too long.
+ * Fails if a built page's title or meta description is missing or malformed.
  *
  *     npm run build && npm run check:meta
  *
- * Bing truncates meta descriptions at roughly 155 characters, which is the
- * tighter of the two limits that matter to us; Google's is longer and varies.
- * A description that overruns is not an error anyone sees locally, so it went
- * unnoticed until three of five pages were over. Hence a check.
+ * Bing truncates meta descriptions at roughly 155 characters and titles at
+ * roughly 70, and those are the tighter of the two limits that matter to us;
+ * Google's are longer and vary. Neither overrun is an error anyone sees
+ * locally — the page looks fine, and only the search result is cut — so both
+ * went unnoticed until three of five descriptions were over. Hence a check.
  *
- * This reads dist rather than src on purpose. The description reaches the page
- * by three different routes — a prop on index.astro and about.astro, a prop on
- * work/index.astro, and frontmatter on each note, threaded through
- * notes/[...slug].astro — and a source-level check would have to know all
- * three, and would miss a fourth added later. The built HTML is the only place
- * every route converges, and it is what a crawler actually reads.
+ * This reads dist rather than src on purpose. Title and description reach a
+ * page by several routes — props on the page, frontmatter on a note threaded
+ * through notes/[...slug].astro, and the brand suffix that Seo.astro appends
+ * on the way out — and a source-level check would have to know all of them,
+ * and would still miss the suffix, which is where the home page overran. The
+ * built HTML is the only place every route converges, and it is what a crawler
+ * actually reads.
  *
- * Entities are decoded before counting so that an apostrophe escaped as &#39;
+ * The home page is the one page that sets titleIsComplete and so carries no
+ * " | OkArthur" suffix, because with it the title ran to 78 characters. Every
+ * other page must still carry the suffix, and og:title must agree with <title>
+ * everywhere: a page is called one thing, not two. The brand still reaches a
+ * share unfurl through og:site_name, which is asserted here too.
+ *
+ * Entities are decoded before counting, so an apostrophe escaped as &#39;
  * counts as the one character a crawler sees, not six.
  */
 import { readdirSync, readFileSync, statSync } from 'node:fs';
@@ -25,7 +33,11 @@ import { dirname, join, relative } from 'node:path';
 const here = dirname(fileURLToPath(import.meta.url));
 const DIST = join(here, '..', 'dist');
 
-const LIMIT = 155;
+const DESC_LIMIT = 155;
+const TITLE_LIMIT = 70;
+const BRAND_SUFFIX = ' | OkArthur';
+const SITE_NAME = 'OkArthur';
+const HOME = 'index.html';
 
 function htmlFiles(dir) {
 	const out = [];
@@ -47,6 +59,13 @@ const decode = (s) =>
 		.replace(/&nbsp;/g, ' ')
 		.replace(/&amp;/g, '&');
 
+const attr = (html, prop) => {
+	const m = html.match(
+		new RegExp(`<meta\\s+(?:name|property)="${prop}"\\s+content="([^"]*)"\\s*/?>`, 'i')
+	);
+	return m ? decode(m[1]) : null;
+};
+
 let files;
 try {
 	files = htmlFiles(DIST).sort();
@@ -62,41 +81,115 @@ if (files.length === 0) {
 
 const pages = files.map((file) => {
 	const html = readFileSync(file, 'utf8');
-	const m = html.match(/<meta\s+name="description"\s+content="([^"]*)"\s*\/?>/i);
-	return { path: relative(DIST, file), desc: m ? decode(m[1]) : null };
+	const t = html.match(/<title>([\s\S]*?)<\/title>/i);
+	return {
+		path: relative(DIST, file),
+		title: t ? decode(t[1].trim()) : null,
+		ogTitle: attr(html, 'og:title'),
+		siteName: attr(html, 'og:site_name'),
+		desc: attr(html, 'description'),
+	};
 });
 
-pages.sort((a, b) => (b.desc?.length ?? -1) - (a.desc?.length ?? -1));
+const len = (s) => (s === null ? -1 : [...s].length);
+const isHome = (p) => p.path === HOME;
 
-for (const { path, desc } of pages) {
-	if (desc === null) {
-		console.log(`  missing  ---  ${path}`);
+const failures = [];
+const fail = (msg) => failures.push(msg);
+
+// Titles, longest first.
+console.log(`Titles, limit ${TITLE_LIMIT}\n`);
+for (const p of [...pages].sort((a, b) => len(b.title) - len(a.title))) {
+	if (p.title === null) {
+		console.log(`  missing  ---  ${p.path}`);
 		continue;
 	}
-	const n = [...desc].length;
-	console.log(`  ${n > LIMIT ? 'OVER' : '  ok'}  ${String(n).padStart(3)}  ${path}`);
+	const n = len(p.title);
+	console.log(`  ${n > TITLE_LIMIT ? 'OVER' : '  ok'}  ${String(n).padStart(3)}  ${p.path}`);
+	console.log(`             ${p.title}`);
 }
 
-const missing = pages.filter((p) => p.desc === null);
-const over = pages.filter((p) => p.desc && [...p.desc].length > LIMIT);
-
-for (const { path } of missing) {
-	console.error(`\n${path} has no meta description.`);
+// Descriptions, longest first.
+console.log(`\nDescriptions, limit ${DESC_LIMIT}\n`);
+for (const p of [...pages].sort((a, b) => len(b.desc) - len(a.desc))) {
+	if (p.desc === null) {
+		console.log(`  missing  ---  ${p.path}`);
+		continue;
+	}
+	const n = len(p.desc);
+	console.log(`  ${n > DESC_LIMIT ? 'OVER' : '  ok'}  ${String(n).padStart(3)}  ${p.path}`);
+	console.log(`             ${p.desc}`);
 }
-for (const { path, desc } of over) {
-	console.error(
-		`\n${path} has a ${[...desc].length} character meta description, ` +
-			`${LIMIT} is the limit:\n  ${desc}`
-	);
+
+// Assertions.
+const home = pages.find(isHome);
+if (!home) fail(`No ${HOME} in dist. The home page is the one that skips the suffix.`);
+
+for (const p of pages) {
+	if (p.title === null) fail(`${p.path} has no <title>.`);
+	else if (len(p.title) > TITLE_LIMIT)
+		fail(`${p.path} title is ${len(p.title)} characters, ${TITLE_LIMIT} is the limit: ${p.title}`);
+
+	if (p.desc === null) fail(`${p.path} has no meta description.`);
+	else if (len(p.desc) > DESC_LIMIT)
+		fail(`${p.path} description is ${len(p.desc)} characters, ${DESC_LIMIT} is the limit: ${p.desc}`);
+
+	if (p.title !== null) {
+		if (isHome(p)) {
+			if (p.title.includes('|'))
+				fail(`${p.path} title contains a pipe; the home page carries no brand suffix: ${p.title}`);
+		} else if (!p.title.endsWith(BRAND_SUFFIX)) {
+			fail(`${p.path} title does not end in "${BRAND_SUFFIX}": ${p.title}`);
+		}
+	}
+
+	if (p.ogTitle === null) fail(`${p.path} has no og:title.`);
+	else if (p.ogTitle !== p.title)
+		fail(`${p.path} og:title differs from <title>:\n    <title>  ${p.title}\n    og:title ${p.ogTitle}`);
+
+	if (p.siteName === null) fail(`${p.path} has no og:site_name.`);
+	else if (p.siteName !== SITE_NAME)
+		fail(`${p.path} og:site_name is "${p.siteName}", expected "${SITE_NAME}".`);
 }
 
-if (missing.length || over.length) {
-	console.error(
-		`\nFailed: ${over.length} over ${LIMIT} characters, ${missing.length} missing.`
-	);
+// One pass or fail line per assertion, in the order they were asked for.
+const others = pages.filter((p) => !isHome(p));
+const check = (label, ok) => console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${label}`);
+
+console.log('\nAssertions\n');
+check(
+	`no <title> exceeds ${TITLE_LIMIT} characters`,
+	pages.every((p) => p.title !== null && len(p.title) <= TITLE_LIMIT)
+);
+check(
+	`no description exceeds ${DESC_LIMIT} characters`,
+	pages.every((p) => p.desc !== null && len(p.desc) <= DESC_LIMIT)
+);
+check(
+	'the home page title contains no pipe',
+	!!home && home.title !== null && !home.title.includes('|')
+);
+check(
+	`every page but the home page has a title ending in "${BRAND_SUFFIX}"`,
+	others.every((p) => p.title !== null && p.title.endsWith(BRAND_SUFFIX))
+);
+check(
+	'every page but the home page has og:title identical to its <title>',
+	others.every((p) => p.ogTitle !== null && p.ogTitle === p.title)
+);
+check(
+	'the home page has og:title identical to its <title>',
+	!!home && home.ogTitle !== null && home.ogTitle === home.title
+);
+check(
+	`og:site_name is present and reads "${SITE_NAME}" on every page`,
+	pages.every((p) => p.siteName === SITE_NAME)
+);
+
+if (failures.length) {
+	console.error(`\nFailed: ${failures.length} problem(s).\n`);
+	for (const f of failures) console.error(`  ${f}`);
 	process.exit(1);
 }
 
-console.log(
-	`\n${pages.length} pages checked, none over ${LIMIT} characters.`
-);
+console.log(`\n${pages.length} pages checked, all assertions passed.`);

--- a/site/src/components/Seo.astro
+++ b/site/src/components/Seo.astro
@@ -1,6 +1,12 @@
 ---
 interface Props {
 	title: string;
+	/* Set when title is already the whole title, and the brand suffix would
+	   only push it past Bing's 70 character ceiling. Governs <title> and
+	   og:title together: a page is called one thing, not two. Dropping the
+	   suffix from og:title costs nothing, because og:site_name below still
+	   carries OkArthur into a share unfurl. */
+	titleIsComplete?: boolean;
 	description: string;
 	ogType?: 'website' | 'article';
 	noindex?: boolean;
@@ -9,6 +15,7 @@ interface Props {
 
 const {
 	title,
+	titleIsComplete = false,
 	description,
 	ogType = 'website',
 	noindex = false,
@@ -19,7 +26,9 @@ const {
 	image = '/og-default-v3.png',
 } = Astro.props;
 
-const fullTitle = `${title} | OkArthur`;
+const BRAND_SUFFIX = ' | OkArthur';
+
+const fullTitle = titleIsComplete ? title : `${title}${BRAND_SUFFIX}`;
 
 /** Resolve against Astro.site so the canonical is absolute in dev too. */
 const canonical = new URL(Astro.url.pathname, Astro.site).href;

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -5,6 +5,8 @@ import '../styles/global.css';
 
 interface Props {
 	title: string;
+	/** Suppress the brand suffix; title is already complete. See Seo.astro. */
+	titleIsComplete?: boolean;
 	description: string;
 	ogType?: 'website' | 'article';
 	/** Schemas to emit alongside the site-wide Person. */
@@ -15,7 +17,8 @@ interface Props {
 	image?: string;
 }
 
-const { title, description, ogType, schema, noindex, image } = Astro.props;
+const { title, titleIsComplete, description, ogType, schema, noindex, image } =
+	Astro.props;
 
 const path = Astro.url.pathname;
 
@@ -79,6 +82,7 @@ const isCurrent = (href: string) =>
 
 		<Seo
 			title={title}
+			titleIsComplete={titleIsComplete}
 			description={description}
 			ogType={ogType}
 			noindex={noindex}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -49,6 +49,7 @@ const gateways = [
 
 <Base
 	title="Steven Yule, independent advice on digital and AI in infrastructure"
+	titleIsComplete
 	description="Steven Yule, chartered civil engineer in Dubai. Independent advice on digital and AI in infrastructure. Review, advisory and board work."
 	schema={[website]}
 >


### PR DESCRIPTION
## Why

`Seo.astro` appended `" | OkArthur"` to every title without exception, which took the home page to 78 characters. Bing cuts at roughly 70, so the one page whose title has to do the most work was the one being truncated.

## What

A page can now pass `titleIsComplete` and supply its whole title. Only the home page does. Every other page is untouched: the prop defaults to `false` and the suffix is appended exactly as before.

The home page title string itself is unchanged — 67 characters, as it already was. The only difference is that the suffix is suppressed.

## The prop governs both tags

`titleIsComplete` controls `<title>` and `og:title` together, not either alone. A page is called one thing, not two, and letting the two disagree is a bug waiting to happen. Nothing is lost from a share unfurl, because `og:site_name` already emits OkArthur on every page.

## check:meta now covers titles too

So a regression fails CI rather than reaching production:

- no `<title>` over 70 characters, no description over 155
- the home page title contains no pipe
- every other page's title ends in `" | OkArthur"`
- `og:title` is identical to `<title>` on every page, home included
- `og:site_name` is present and reads OkArthur on every page

The suffix rules matter most: a second page setting `titleIsComplete` would otherwise silently drop its brand, and nothing would say so.

## Verified

Against the built output. All 13 pages pass all seven assertions. The home page is 67 characters with no suffix; the next longest is the digital twin note at 53, so nothing else is near the ceiling.

Every failure path was exercised by doctoring `dist`: stripping the suffix from the About title, pushing the home title to 78 with a pipe, and changing `og:site_name` on Terms. All five affected assertions failed and the script exited 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)