### PR TITLE
Feed title, feed discovery, GitHub sameAs, straight apostrophes

### DIFF
--- a/.github/workflows/astro-ci.yml
+++ b/.github/workflows/astro-ci.yml
@@ -19,7 +19,7 @@ jobs:
         working-directory: site
       # A step of build, not a job of its own: it needs the same dist the build
       # just produced, and folding it in keeps the required checks at three.
-      - name: Meta descriptions within Bing's 155 character limit
+      - name: Titles and meta descriptions within Bing's limits
         run: npm run check:meta
         working-directory: site
       # lychee does not cover llms.txt: it reads the HTML, and our own domain is
@@ -27,6 +27,12 @@ jobs:
       # would rot the file silently.
       - name: llms.txt links point at routes that exist
         run: npm run check:llms
+        working-directory: site
+      # Astro's markdown SmartyPants is on by default and rewrites straight
+      # apostrophes into curly ones between src and dist. astro.config.mjs turns
+      # it off; this catches a dependency bump that turns it back on.
+      - name: No curly quotes or em dashes in the build output
+        run: npm run check:text
         working-directory: site
 
   gitleaks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ will not fail loudly; it will just do the wrong thing.
                         after a build
     npm run check:llms  asserts every URL in llms.txt is a real route, also
                         reads site/dist, so run it after a build
+    npm run check:text  asserts no curly quotes or em dashes reach the build
+                        output, same again
 
 The Open Graph card is generated, not hand-edited, and is not part of
 `npm run build`. Regenerate it only when the card design changes:
@@ -51,6 +53,9 @@ not "tidy them away" as unused.
     site/scripts/og-card.mjs   generates the Open Graph card, run by hand
     site/scripts/check-meta.mjs  title and meta description check, run in CI
     site/scripts/check-llms.mjs  llms.txt link check, run in CI
+    site/scripts/check-text.mjs  curly quote and em dash check, run in CI
+    site/src/lib/feed.ts       feed title, description and path, imported by
+                               rss.xml.ts and by the head in Base.astro
     site/public/               copied verbatim into dist
 
 `notes` is two files: `notes/index.astro` for the list and
@@ -116,6 +121,16 @@ without the check a renamed route leaves `llms.txt` pointing at a 404 and
 nothing says so. The reverse is not asserted, because plenty of routes
 belong in the sitemap and not in `llms.txt`: the individual notes, privacy,
 terms.
+
+`build` also runs `npm run check:text`, which fails the job if a curly quote
+or an em dash reaches `site/dist`. Astro runs SmartyPants over markdown by
+default, which rewrites the straight apostrophes in the note sources into
+curly ones between `src` and `dist`. The sources were always clean, so a grep
+of `src/` finds nothing and the characters appear only in the build.
+`astro.config.mjs` sets `markdown.smartypants` to `false`; the check is what
+stops a dependency bump quietly restoring the default. If a piece of copy
+ever genuinely needs an em dash, change the check deliberately rather than
+working around it.
 
 `linkcheck` runs lychee over `site/dist`. Its `--exclude` flags are
 load-bearing and documented in the workflow: our own domain (canonical

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -6,4 +6,13 @@ import sitemap from '@astrojs/sitemap';
 export default defineConfig({
   site: 'https://okarthur.com',
   integrations: [sitemap()],
+  markdown: {
+    // Astro runs SmartyPants over markdown by default, which turns the straight
+    // apostrophes in the note sources into curly ones on the way to HTML. The
+    // source stays clean, so a grep of src/ finds nothing, and the curly
+    // characters appear only in the build. Off, so that what is written is what
+    // is served. Nothing is lost: no note uses -- or ..., so em dash and
+    // ellipsis conversion were doing no work. Enforced by scripts/check-text.mjs.
+    smartypants: false,
+  },
 });

--- a/site/package.json
+++ b/site/package.json
@@ -11,6 +11,7 @@
     "build": "astro build",
     "check:llms": "node scripts/check-llms.mjs",
     "check:meta": "node scripts/check-meta.mjs",
+    "check:text": "node scripts/check-text.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/site/scripts/check-text.mjs
+++ b/site/scripts/check-text.mjs
@@ -1,0 +1,101 @@
+/**
+ * Fails if the build output contains a curly quote or an em dash.
+ *
+ *     npm run build && npm run check:text
+ *
+ * Astro runs SmartyPants over markdown by default, which rewrites the straight
+ * apostrophes in the note sources into curly ones somewhere between src and
+ * dist. That is why this reads dist and not src: the sources were always clean,
+ * a grep of src/ found nothing, and the curly characters existed only in the
+ * built HTML. astro.config.mjs now sets smartypants: false, and this check is
+ * what stops it coming back — a dependency bump that restored the default would
+ * otherwise reintroduce it silently, and nothing on the page would look wrong.
+ *
+ * The em dash is included because the same transform produces it, from a double
+ * hyphen, and because the house style does not use it. If a piece of copy ever
+ * genuinely needs one, this is the check to change, deliberately.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const DIST = join(here, '..', 'dist');
+
+const FORBIDDEN = [
+	['U+2018', 'left single curly quote', '‘'],
+	['U+2019', 'right single curly quote', '’'],
+	['U+201C', 'left double curly quote', '“'],
+	['U+201D', 'right double curly quote', '”'],
+	['U+2014', 'em dash', '—'],
+];
+
+/* Anything a reader or a crawler reads as text. Fonts and images are binary and
+   would only produce noise. */
+const TEXT = /\.(html|xml|txt|json|css|js|mjs|svg)$/i;
+
+function files(dir) {
+	const out = [];
+	for (const entry of readdirSync(dir)) {
+		const full = join(dir, entry);
+		if (statSync(full).isDirectory()) out.push(...files(full));
+		else out.push(full);
+	}
+	return out;
+}
+
+let all;
+try {
+	all = files(DIST);
+} catch {
+	console.error('No dist directory. Run `npm run build` first.');
+	process.exit(1);
+}
+
+const scanned = all.filter((f) => TEXT.test(f)).sort();
+if (scanned.length === 0) {
+	console.error('dist contains no text files. Did the build succeed?');
+	process.exit(1);
+}
+
+const hits = [];
+for (const file of scanned) {
+	const lines = readFileSync(file, 'utf8').split('\n');
+	lines.forEach((line, i) => {
+		for (const [code, name, ch] of FORBIDDEN) {
+			let col = line.indexOf(ch);
+			while (col !== -1) {
+				hits.push({
+					path: relative(DIST, file),
+					line: i + 1,
+					col: col + 1,
+					code,
+					name,
+					/* Enough of the line to recognise, not the whole of a minified one. */
+					context: line.slice(Math.max(0, col - 40), col + 40).trim(),
+				});
+				col = line.indexOf(ch, col + 1);
+			}
+		}
+	});
+}
+
+for (const [code, name, ch] of FORBIDDEN) {
+	const n = hits.filter((h) => h.code === code).length;
+	console.log(`  ${code}  ${name.padEnd(26)}  ${n} match(es)`);
+}
+
+if (hits.length) {
+	console.error(`\nFailed: ${hits.length} forbidden character(s) in the build output.\n`);
+	for (const h of hits) {
+		console.error(`  ${h.path}:${h.line}:${h.col}  ${h.code} ${h.name}`);
+		console.error(`    ${h.context}`);
+	}
+	console.error(
+		'\nIf these came from markdown, check that astro.config.mjs still sets\n' +
+			'markdown.smartypants to false. Astro turns it on by default.'
+	);
+	process.exit(1);
+}
+
+console.log(`\n${scanned.length} text files checked, none contain a curly quote or an em dash.`);

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -1,6 +1,7 @@
 ---
 import JsonLd from '../components/JsonLd.astro';
 import Seo from '../components/Seo.astro';
+import { FEED_TITLE, FEED_PATH } from '../lib/feed';
 import '../styles/global.css';
 
 interface Props {
@@ -79,6 +80,13 @@ const isCurrent = (href: string) =>
 		/>
 
 		{noindex && <meta name="robots" content="noindex" />}
+
+		<link
+			rel="alternate"
+			type="application/rss+xml"
+			title={FEED_TITLE}
+			href={FEED_PATH}
+		/>
 
 		<Seo
 			title={title}

--- a/site/src/lib/feed.ts
+++ b/site/src/lib/feed.ts
@@ -1,0 +1,14 @@
+/** The feed's identity, in one place.
+ *
+ * The title is written once and imported by both the feed itself and the
+ * discovery link in the head. A reader shows the title attribute of that link
+ * before it has fetched anything, so if the two ever disagreed, the feed would
+ * appear to change its name the moment it was subscribed to.
+ */
+export const FEED_TITLE = 'OkArthur, notes';
+
+export const FEED_DESCRIPTION =
+	'Notes from Steven Yule on digital and AI in infrastructure and capital programmes.';
+
+/** Where rss.xml.ts builds to, and so what the discovery link points at. */
+export const FEED_PATH = '/rss.xml';

--- a/site/src/lib/schema.ts
+++ b/site/src/lib/schema.ts
@@ -16,7 +16,12 @@ export const person = {
 		addressLocality: 'Dubai',
 		addressCountry: 'AE',
 	},
-	sameAs: ['https://www.linkedin.com/in/stevenyule'],
+	/* An identity claim, not a link list: these say the Person is that profile.
+	   The GitHub account is styule, not the unrelated and empty stevenyule. */
+	sameAs: [
+		'https://www.linkedin.com/in/stevenyule',
+		'https://github.com/styule',
+	],
 	memberOf: [
 		{
 			'@type': 'Organization',

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -12,7 +12,7 @@ import Base from '../layouts/Base.astro';
 
 	<div class="prose">
 		<p>
-			We don’t collect personal data on this site. If you email us, we’ll use
+			We don't collect personal data on this site. If you email us, we'll use
 			your message only to respond. To request updates or deletion,
 			contact <a href="mailto:steven@okarthur.com">steven@okarthur.com</a>.
 		</p>

--- a/site/src/pages/rss.xml.ts
+++ b/site/src/pages/rss.xml.ts
@@ -1,14 +1,14 @@
 import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
+import { FEED_TITLE, FEED_DESCRIPTION } from '../lib/feed';
 
 export async function GET(context: APIContext) {
 	const notes = await getCollection('notes', ({ data }) => !data.draft);
 
 	return rss({
-		title: 'OkArthur — Notes',
-		description:
-			'Notes from Steven Yule on digital and AI investment decisions in infrastructure and capital programmes.',
+		title: FEED_TITLE,
+		description: FEED_DESCRIPTION,
 		site: context.site!,
 		items: notes
 			.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())

--- a/site/src/pages/terms.astro
+++ b/site/src/pages/terms.astro
@@ -12,7 +12,7 @@ import Base from '../layouts/Base.astro';
 
 	<div class="prose">
 		<p>
-			Content on this website is provided “as is” without warranty. Do not rely
+			Content on this website is provided "as is" without warranty. Do not rely
 			on it as legal, financial, or professional advice.
 		</p>
 	</div>


### PR DESCRIPTION
## Feed title, defined once

`src/lib/feed.ts` is new and exports `FEED_TITLE`, `FEED_DESCRIPTION` and `FEED_PATH`. Both `rss.xml.ts` and the head in `Base.astro` import the title from there rather than repeating the literal. A reader shows the discovery link's `title` attribute before it has fetched the feed, so two copies of the string would let the feed appear to rename itself the moment someone subscribed.

The title is now `OkArthur, notes`, which also drops the em dash it used to carry.

## Feed discovery

There was **no** `application/rss+xml` link anywhere in `src` — I grepped for it. The feed built and was reachable at `/rss.xml`, but nothing could discover it from a page. There is now one on every page, its `href` pointing at the feed and its `title` taking the imported constant.

## sameAs: styule, not stevenyule

The instruction was to add `https://github.com/stevenyule` if it returned 200. **It did return 200, and I did not add it.** That account is empty — no name, no bio, no repos — and is not Steven's. His is `styule`: named Steven Yule, company OkArthur, Dubai, linking back to okarthur.com.

`sameAs` is an identity assertion, not a link list. Pointing it at a stranger's profile would have undone the disambiguation work in `7d78639`, "Make the Person entity separable from other Steven Yules". Confirmed with Steven before changing it.

## Straight apostrophes, and why a find-and-replace was not enough

`terms.astro` and `privacy.astro` had curly quotes in source; those are now straight.

The built notes also carried curly apostrophes, but **their sources never did**. Astro runs SmartyPants over markdown by default and rewrites straight apostrophes into curly ones between `src` and `dist` — which is exactly why a grep of `src/` found nothing. `astro.config.mjs` now sets `markdown.smartypants: false`. Nothing is lost: no note uses `--` or `...`, so em dash and ellipsis conversion were doing no work.

## Enforced in CI

New `check:text` step on the `build` job fails if a curly quote or an em dash reaches `site/dist`. Without it, a dependency bump that restored Astro's default would reintroduce the problem silently, and nothing on the page would look wrong.

Verified by turning `smartypants` back on and rebuilding: the check caught all three apostrophes with file, line and column, and exited 1.

## Verified against the built output

- `rss.xml` title `OkArthur, notes`, description as specified, zero U+2014.
- Exactly one `application/rss+xml` link on the home page; `href="/rss.xml"` resolves to a real 1,508-byte file in `dist`; its title matches the feed's; the link is present on all 13 built pages.
- Home page JSON-LD Person `sameAs`: LinkedIn plus `https://github.com/styule`.
- Zero curly quotes across all 21 text files in the build output.
- `check:meta` and `check:llms` both still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)